### PR TITLE
Update LastFullSweepTime if the index doesn't exist

### DIFF
--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/JobSweeper.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/JobSweeper.kt
@@ -261,6 +261,7 @@ class JobSweeper(
         if (!clusterState.routingTable.hasIndex(ScheduledJob.SCHEDULED_JOBS_INDEX)) {
             scheduler.deschedule(scheduler.scheduledJobs())
             sweptJobs.clear()
+            lastFullSweepTimeNano = System.nanoTime()
             return
         }
 


### PR DESCRIPTION
*Description of changes:*
LastFullSweepTime does not get updated if the ScheduledJob Index doesn't exist. This commit is to fix that issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
