### PR TITLE
Upgrade to ES 6.7

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertMover.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertMover.kt
@@ -150,7 +150,7 @@ class AlertMover(
             val runnable = Runnable {
                 monitorRunner.rescheduleAlertMover(monitorId, monitor, backoff)
             }
-            threadPool.schedule(wait, ThreadPool.Names.SAME, runnable)
+            threadPool.schedule(runnable, wait, ThreadPool.Names.SAME)
         } else {
             logger.warn("Retries exhausted for ${monitorIdTriggerIdsTuple()}")
         }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -278,7 +278,6 @@ abstract class AlertingRestTestCase : ESRestTestCase() {
     override fun restClientSettings(): Settings {
         return if (isDebuggingTest || isDebuggingRemoteCluster) {
             Settings.builder()
-                    .put(CLIENT_RETRY_TIMEOUT, TimeValue.timeValueMinutes(10))
                     .put(CLIENT_SOCKET_TIMEOUT, TimeValue.timeValueMinutes(10))
                     .build()
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        es_version = '6.7.0'
+        es_version = '6.7.1'
         kotlin_version = '1.3.21'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        es_version = '6.6.2'
+        es_version = '6.7.0'
         kotlin_version = '1.3.21'
     }
 
@@ -41,7 +41,7 @@ apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
-    opendistroVersion = '0.8.0'
+    opendistroVersion = '0.9.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/schedule/JobScheduler.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/schedule/JobScheduler.kt
@@ -19,11 +19,11 @@ import com.amazon.opendistroforelasticsearch.alerting.core.JobRunner
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.common.unit.TimeValue
+import org.elasticsearch.threadpool.Scheduler
 import org.elasticsearch.threadpool.ThreadPool
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
@@ -81,7 +81,7 @@ class JobScheduler(private val threadPool: ThreadPool, private val jobRunner: Jo
         val scheduledJobInfo = scheduledJobIdToInfo.getOrPut(scheduledJob.id) {
             ScheduledJobInfo(scheduledJob.id, scheduledJob)
         }
-        if (scheduledJobInfo.scheduledFuture != null) {
+        if (scheduledJobInfo.scheduledCancellable != null) {
             // This means that the given ScheduledJob already has schedule running. We should not schedule any more.
             return true
         }
@@ -131,10 +131,10 @@ class JobScheduler(private val threadPool: ThreadPool, private val jobRunner: Jo
             scheduledJobInfo.actualPreviousExecutionTime = null
             scheduledJobInfo.expectedNextExecutionTime = null
             var result = true
-            val scheduledFuture = scheduledJobInfo.scheduledFuture
+            val scheduledFuture = scheduledJobInfo.scheduledCancellable
 
-            if (scheduledFuture != null && !scheduledFuture.isDone) {
-                result = scheduledFuture.cancel(false)
+            if (scheduledFuture != null && !scheduledFuture.isCancelled) {
+                result = scheduledFuture.cancel()
             }
 
             if (result) {
@@ -194,8 +194,8 @@ class JobScheduler(private val threadPool: ThreadPool, private val jobRunner: Jo
         }
 
         // Finally schedule the job in the ThreadPool with next time to execute.
-        val scheduledFuture = threadPool.schedule(TimeValue(duration.toNanos(), TimeUnit.NANOSECONDS), ThreadPool.Names.SAME, runnable)
-        scheduledJobInfo.scheduledFuture = scheduledFuture
+        val scheduledCancellable = threadPool.schedule(runnable, TimeValue(duration.toNanos(), TimeUnit.NANOSECONDS), ThreadPool.Names.SAME)
+        scheduledJobInfo.scheduledCancellable = scheduledCancellable
 
         return true
     }
@@ -230,6 +230,6 @@ class JobScheduler(private val threadPool: ThreadPool, private val jobRunner: Jo
         var descheduled: Boolean = false,
         var actualPreviousExecutionTime: Instant? = null,
         var expectedNextExecutionTime: Instant? = null,
-        var scheduledFuture: ScheduledFuture<*>? = null
+        var scheduledCancellable: Scheduler.ScheduledCancellable? = null
     )
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip


### PR DESCRIPTION
*Description of changes:*

1. Upgrade to ES 6.7.1 and Gradle 5.2.1 (upstream Gradle version used by ES 6.7)

1. **`Scheduler.schedule` has been deprecated.**
`Scheduler.ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command)` has been deprecated and replace to `ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor)`. Related: https://github.com/elastic/elasticsearch/commit/68ed72b92395fdbc777cad9046a6be4d695b9cd4#diff-0e2c2d1682285e7920440dbc4a5a49bf
1. **Client RetryTimeout is removed.**
This was being used in the unit test in Alerting and it is not longer supported. Related https://github.com/elastic/elasticsearch/commit/99192e7f0ca30be9b43fc26e38345ea4f70a28c8#diff-ffbc192f9ee093f558b3b55dcdc2d63f


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
