### PR TITLE
Add http proxy support to outgoing notifcations

### DIFF
--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
@@ -70,6 +70,7 @@ public class DestinationHttpClient {
                 .setDefaultRequestConfig(config)
                 .setConnectionManager(connectionManager)
                 .setRetryHandler(new DefaultHttpRequestRetryHandler())
+                .useSystemProperties()
                 .build();
     }
 


### PR DESCRIPTION
Add proxy support for outgoing notifications by looking at system properties.

*Issue:* https://github.com/opendistro-for-elasticsearch/alerting/issues/22

*Description of changes:* Simply call useSystemProperties() which then finds and uses properties such as http.proxyHost, http.proxyPort, https.proxyHost...


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
