### PR TITLE
Adds more alert properties to templateArgs for context variable

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
@@ -71,6 +71,8 @@ data class Alert(
 
     companion object {
 
+        const val ALERT_ID_FIELD = "id"
+        const val ALERT_VERSION_FIELD = "version"
         const val MONITOR_ID_FIELD = "monitor_id"
         const val MONITOR_VERSION_FIELD = "monitor_version"
         const val MONITOR_NAME_FIELD = "monitor_name"
@@ -169,9 +171,14 @@ data class Alert(
     }
 
     fun asTemplateArg(): Map<String, Any?> {
-        return mapOf(STATE_FIELD to state.toString(),
+        return mapOf(ACKNOWLEDGED_TIME_FIELD to acknowledgedTime?.toEpochMilli(),
+                ALERT_ID_FIELD to id,
+                ALERT_VERSION_FIELD to version,
+                END_TIME_FIELD to endTime?.toEpochMilli(),
                 ERROR_MESSAGE_FIELD to errorMessage,
-                ACKNOWLEDGED_TIME_FIELD to acknowledgedTime?.toEpochMilli(),
-                LAST_NOTIFICATION_TIME_FIELD to lastNotificationTime?.toEpochMilli())
+                LAST_NOTIFICATION_TIME_FIELD to lastNotificationTime?.toEpochMilli(),
+                SEVERITY_FIELD to severity,
+                START_TIME_FIELD to startTime.toEpochMilli(),
+                STATE_FIELD to state.toString())
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AlertTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AlertTests.kt
@@ -24,15 +24,15 @@ class AlertTests : ESTestCase() {
 
         val templateArgs = alert.asTemplateArg()
 
-        assertEquals("Template args state does not match", templateArgs["state"], alert.state.toString())
-        assertEquals("Template args error message does not match", templateArgs["error_message"], alert.errorMessage)
-        assertEquals(
-                "Template args acknowledged time does not match",
-                templateArgs["acknowledged_time"],
-                alert.acknowledgedTime?.toEpochMilli())
-        assertEquals("Template args last notification time does not match",
-                templateArgs["last_notification_time"],
-                alert.lastNotificationTime?.toEpochMilli())
+        assertEquals("Template args id does not match", templateArgs[Alert.ALERT_ID_FIELD], alert.id)
+        assertEquals("Template args version does not match", templateArgs[Alert.ALERT_VERSION_FIELD], alert.version)
+        assertEquals("Template args state does not match", templateArgs[Alert.STATE_FIELD], alert.state.toString())
+        assertEquals("Template args error message does not match", templateArgs[Alert.ERROR_MESSAGE_FIELD], alert.errorMessage)
+        assertEquals("Template args acknowledged time does not match", templateArgs[Alert.ACKNOWLEDGED_TIME_FIELD], null)
+        assertEquals("Template args end time does not", templateArgs[Alert.END_TIME_FIELD], alert.endTime?.toEpochMilli())
+        assertEquals("Template args start time does not", templateArgs[Alert.START_TIME_FIELD], alert.startTime.toEpochMilli())
+        assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
+        assertEquals("Template args severity does not match", templateArgs[Alert.SEVERITY_FIELD], alert.severity)
     }
 
     fun `test alert acknowledged`() {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting/issues/25

*Description of changes:*
This adds new alert properties to the alert templateArgs method which is used when creating the context variable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
