### PR TITLE
Support ES 6.8.1 and upgrade to OpenDistro 0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        es_version = '6.7.1'
+        es_version = '6.8.1'
         kotlin_version = '1.3.21'
     }
 
@@ -41,7 +41,7 @@ apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
-    opendistroVersion = '0.9.0'
+    opendistroVersion = '0.10.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/opendistro-elasticsearch-alerting.release-notes.md
+++ b/opendistro-elasticsearch-alerting.release-notes.md
@@ -1,14 +1,19 @@
-## Version 0.9.0 (Current)
+## Version 0.10.0 (Current)
 
 ### New Features
-* Adds support for Elasticsearch 6.7.1 - #19 
-* Add http proxy support to outgoing notifications - #23 
-* Allow encoding while constructing HTTP request for sending notification - [PR # 35](https://github.com/opendistro-for-elasticsearch/alerting/pull/35)
-* Add build for Debian - #36
+  * Adds support for Elasticsearch 6.8.1 - [PR #75](https://github.com/opendistro-for-elasticsearch/alerting/pull/75)
+
+## 2019-04-24, Version 0.9.0
+
+### New Features
+  * Adds support for Elasticsearch 6.7.1 - #19
+  * Add http proxy support to outgoing notifications - #23
+  * Allow encoding while constructing HTTP request for sending notification - [PR # 35](https://github.com/opendistro-for-elasticsearch/alerting/pull/35)
+  * Add build for Debian - #36
 
 ### Bug fixes
-* Fix update LastFullSweepTime if the index doesn't exist - #17
-* Adds more alert properties to templateArgs for context variable - #26
+  * Fix update LastFullSweepTime if the index doesn't exist - #17
+  * Adds more alert properties to templateArgs for context variable - #26
 
 ## 2019-04-02, Version 0.8.0
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support ES 6.8.1 and upgrade to OpenDistro 0.10

*Build output:*
```
qreshi$ ./gradlew clean

> Configure project :alerting
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.2.1
  OS Info               : Mac OS X 10.12.6 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12 [Java HotSpot(TM) 64-Bit Server VM 12+33])
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-12.jdk/Contents/Home
  Random Testing Seed   : 25644C5C623B096A
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
4 actionable tasks: 4 executed

qreshi$ ./gradlew build

> Configure project :alerting
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.2.1
  OS Info               : Mac OS X 10.12.6 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12 [Java HotSpot(TM) 64-Bit Server VM 12+33])
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-12.jdk/Contents/Home
  Random Testing Seed   : 4CAD3769BCF8A82A
=======================================

> Task :alerting-notification:compileJava
Note: /Users/qreshi/workspace/OpenDistro/Alerting/alerting/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/Notification.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :alerting:unitTest
==> Test Info: seed=4CAD3769BCF8A82A; jvms=2; suites=4
==> Test Summary: 4 suites, 17 tests

> Task :alerting:integTestRunner
==> Test Info: seed=4CAD3769BCF8A82A; jvm=1; suites=4
==> Test Summary: 4 suites, 69 tests

> Task :alerting-notification:test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.easymock.cglib.core.ReflectUtils$1 (file:/Users/qreshi/.gradle/caches/modules-2/files-2.1/org.easymock/easymock/4.0.1/26f1c39bd323b6ac7fe0c4c8e33bfdffcdde03a2/easymock-4.0.1.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.easymock.cglib.core.ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3m 19s
51 actionable tasks: 50 executed, 1 up-to-date
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
