### PR TITLE
Adding new type of input for Monitors - HttpInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Please see our [documentation](https://opendistro.github.io/for-elasticsearch-do
 1. Check out this package from version control.
 1. Launch Intellij IDEA, choose **Import Project**, and select the `settings.gradle` file in the root of this package. 
 1. To build from the command line, set `JAVA_HOME` to point to a JDK >= 12 before running `./gradlew`.
+  - Unix System
+    1. `export JAVA_HOME=jdk-install-dir`: Replace `jdk-install-dir` by the JAVA_HOME directory of your system.
+    1. `export PATH=$JAVA_HOME/bin:$PATH`
+ 
+  - Windows System
+    1. Find **My Computers** from file directory, right click and select **properties**.
+    1. Select the **Advanced** tab, select **Environment variables**.
+    1. Edit **JAVA_HOME** to path of where JDK softeare is installed.
 
 
 ## Build

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -49,7 +49,10 @@ configurations.all {
         force "commons-logging:commons-logging:${versions.commonslogging}"
         force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
         force "commons-codec:commons-codec:${versions.commonscodec}"
-        
+        force "commons-collections:commons-collections:3.2.2"
+        force "org.apache.httpcomponents:httpcore-nio:4.4.11"
+        force "org.apache.httpcomponents:httpclient:4.5.7"
+
         // This is required because kotlin coroutines core-1.1.1 still requires kotin stdlib 1.3.20 and we're using 1.3.21
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
@@ -58,6 +61,7 @@ configurations.all {
 
 dependencies {
     compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${versions.elasticsearch}"
+    compile "org.apache.httpcomponents:httpasyncclient:4.1.4"
 
     // Elasticsearch Nanny state
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -19,6 +19,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.JobSweeper
 import com.amazon.opendistroforelasticsearch.alerting.core.ScheduledJobIndices
 import com.amazon.opendistroforelasticsearch.alerting.core.action.node.ScheduledJobsStatsAction
 import com.amazon.opendistroforelasticsearch.alerting.core.action.node.ScheduledJobsStatsTransportAction
+import com.amazon.opendistroforelasticsearch.alerting.core.model.HttpInput
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.core.resthandler.RestScheduledJobStatsHandler
@@ -118,7 +119,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, P
     }
 
     override fun getNamedXContent(): List<NamedXContentRegistry.Entry> {
-        return listOf(Monitor.XCONTENT_REGISTRY, SearchInput.XCONTENT_REGISTRY)
+        return listOf(Monitor.XCONTENT_REGISTRY, SearchInput.XCONTENT_REGISTRY, HttpInput.XCONTENT_REGISTRY)
     }
 
     override fun createComponents(

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -111,7 +111,7 @@ class MonitorRunner(
 ) : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
 
     private val logger = LogManager.getLogger(MonitorRunner::class.java)
-    private var httpClient: HttpInputClient
+    private lateinit var httpClient: HttpInputClient
     private lateinit var runnerSupervisor: Job
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + runnerSupervisor

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -111,7 +111,7 @@ class MonitorRunner(
 ) : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
 
     private val logger = LogManager.getLogger(MonitorRunner::class.java)
-    private lateinit var httpClient: HttpInputClient
+    private var httpClient: HttpInputClient
     private lateinit var runnerSupervisor: Job
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + runnerSupervisor

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/client/HttpInputClient.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/client/HttpInputClient.kt
@@ -1,0 +1,55 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.client
+
+import com.amazon.opendistroforelasticsearch.alerting.core.model.HttpInput
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
+import org.elasticsearch.common.unit.TimeValue
+import java.security.AccessController
+import java.security.PrivilegedAction
+
+/**
+ * This class takes [HttpInput] and performs GET requests to given URIs.
+ */
+class HttpInputClient {
+
+    // TODO: If possible, these settings should be implemented as changeable via the "_cluster/settings" API.
+    private val CONNECTION_TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(10).millis().toInt()
+    private val REQUEST_TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(10).millis().toInt()
+    private val SOCKET_TIMEOUT_MILLISECONDS = TimeValue.timeValueSeconds(10).millis().toInt()
+
+    val client = createHttpClient()
+
+    /**
+     * Create [CloseableHttpAsyncClient] as a [PrivilegedAction] in order to avoid [java.net.NetPermission] error.
+     */
+    private fun createHttpClient(): CloseableHttpAsyncClient {
+        val config = RequestConfig.custom()
+                .setConnectTimeout(CONNECTION_TIMEOUT_MILLISECONDS)
+                .setConnectionRequestTimeout(REQUEST_TIMEOUT_MILLISECONDS)
+                .setSocketTimeout(SOCKET_TIMEOUT_MILLISECONDS)
+                .build()
+
+        return AccessController.doPrivileged(PrivilegedAction<CloseableHttpAsyncClient>({
+            HttpAsyncClientBuilder.create()
+                    .setDefaultRequestConfig(config)
+                    .useSystemProperties()
+                    .build()
+        } as () -> CloseableHttpAsyncClient))
+    }
+}

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -187,20 +187,16 @@ class RestIndexMonitorAction(
          * This function checks whether the [Monitor] has an [HttpInput] with localhost. If so, make sure the port is same as specified in settings.
          */
         private fun validateLocalPort(monitor: Monitor, settingsPort: Int) {
-            if (monitor.inputs.isNotEmpty()) {
-                        for (input in monitor.inputs) {
-                            if (input is HttpInput) {
-                                val constructedUrl = input.toConstructedUrl()
-                                // Make sure that when host is "localhost", only port number specified in settings is allowed.
-                                if (constructedUrl.host == "localhost") {
-                                    require(constructedUrl.port == settingsPort) {
-                                        "Host: ${constructedUrl.host} is restricted to port $settingsPort."
-                                    }
-                                }
-                            }
+            for (input in monitor.inputs) {
+                if (input is HttpInput) {
+                    val constructedUrl = input.toConstructedUrl()
+                    // Make sure that when host is "localhost", only port number specified in settings is allowed.
+                    if (constructedUrl.host == "localhost") {
+                        require(constructedUrl.port == settingsPort) {
+                            "Host: ${constructedUrl.host} is restricted to port $settingsPort."
                         }
-            } else {
-                return
+                    }
+                }
             }
         }
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -14,6 +14,7 @@
  */
 package com.amazon.opendistroforelasticsearch.alerting
 
+import com.amazon.opendistroforelasticsearch.alerting.core.model.HttpInput
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
@@ -64,6 +65,27 @@ fun randomMonitor(
     return Monitor(name = name, enabled = enabled, inputs = inputs, schedule = schedule, triggers = triggers,
             enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
             uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
+}
+
+fun randomHttpInput(
+    scheme: String = "http",
+    host: String = "localhost",
+    port: Int = randomInt(65535),
+    path: String = ESRestTestCase.randomAlphaOfLength(10),
+    params: Map<String, String> = mapOf(),
+    url: String = "",
+    connection_timeout: Int = randomInt(10000),
+    socket_timeout: Int = randomInt(10000)
+): HttpInput {
+    return HttpInput(
+        scheme = scheme,
+        host = host,
+        port = port,
+        path = path,
+        params = params,
+        url = url,
+        connection_timeout = connection_timeout,
+        socket_timeout = socket_timeout)
 }
 
 fun randomTrigger(

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
     compile "com.cronutils:cron-utils:7.0.5"
-
+    compile "org.apache.httpcomponents:httpasyncclient:4.1.4"
+    compile 'commons-validator:commons-validator:1.6'
+    
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/httpapi/HttpExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/httpapi/HttpExtensions.kt
@@ -1,0 +1,64 @@
+package com.amazon.opendistroforelasticsearch.alerting.core.httpapi
+
+import com.amazon.opendistroforelasticsearch.alerting.core.model.HttpInput
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.apache.http.HttpResponse
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.utils.URIBuilder
+import org.apache.http.concurrent.FutureCallback
+import org.apache.http.nio.client.HttpAsyncClient
+import org.apache.http.util.EntityUtils
+import org.elasticsearch.common.Strings
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.XContentType
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+suspend fun <C : HttpAsyncClient, T> C.suspendUntil(block: C.(FutureCallback<T>) -> Unit): T =
+        suspendCancellableCoroutine { cont ->
+            block(object : FutureCallback<T> {
+                override fun cancelled() {
+                    cont.resumeWith(Result.failure(CancellationException("Request cancelled")))
+                }
+
+                override fun completed(result: T) {
+                    cont.resume(result)
+                }
+
+                override fun failed(ex: Exception) {
+                    cont.resumeWithException(ex)
+                }
+            })
+        }
+
+fun HttpResponse.toMap(): Map<String, Any> {
+    val xcp = XContentType.JSON.xContent().createParser(
+            NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, EntityUtils.toString(this.entity))
+    return xcp.map()
+}
+
+fun HttpInput.toGetRequest(): HttpGet {
+    val requestConfig = RequestConfig.custom()
+            .setConnectTimeout(this.connection_timeout)
+            .setSocketTimeout(this.socket_timeout)
+            .build()
+    // If url field is null or empty, construct an url field by field.
+    val constructedUrl = if (Strings.isNullOrEmpty(this.url)) {
+        val uriBuilder = URIBuilder()
+        uriBuilder.scheme = this.scheme
+        uriBuilder.host = this.host
+        uriBuilder.port = this.port
+        uriBuilder.path = this.path
+        for (e in this.params.entries)
+            uriBuilder.addParameter(e.key, e.value)
+        uriBuilder.build().toString()
+    } else {
+        this.url
+    }
+    val httpGetRequest = HttpGet(constructedUrl)
+    httpGetRequest.config = requestConfig
+    return httpGetRequest
+}

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -1,0 +1,141 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.core.model
+
+import org.apache.commons.validator.routines.UrlValidator
+import org.apache.http.client.utils.URIBuilder
+import org.elasticsearch.common.CheckedFunction
+import org.elasticsearch.common.ParseField
+import org.elasticsearch.common.Strings
+import org.elasticsearch.common.unit.TimeValue
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParserUtils
+import java.io.IOException
+
+/**
+ * This is a data class of HTTP type of input for Monitors.
+ */
+data class HttpInput(
+    val scheme: String,
+    val host: String?,
+    val port: Int,
+    val path: String?,
+    val params: Map<String, String>,
+    val url: String,
+    val connection_timeout: Int,
+    val socket_timeout: Int
+) : Input {
+
+    // Verify parameters are valid during creation
+    init {
+        require(connection_timeout > 0) {
+            "Connection timeout: $connection_timeout is not greater than 0."
+        }
+        require(socket_timeout > 0) {
+            "Socket timeout: $socket_timeout is not greater than 0."
+        }
+
+        // Create an UrlValidator that only accepts "http" and "https" as valid scheme and allows local URLs.
+        val urlValidator = UrlValidator(arrayOf("http", "https"), UrlValidator.ALLOW_LOCAL_URLS)
+
+        // Build url field by field if not provided as whole, and update url field.
+        val constructedUrl = if (Strings.isNullOrEmpty(url)) {
+            val uriBuilder = URIBuilder()
+            uriBuilder.scheme = scheme
+            uriBuilder.host = host
+            uriBuilder.port = port
+            uriBuilder.path = path
+            for (e in params.entries)
+                uriBuilder.addParameter(e.key, e.value)
+            uriBuilder.build().toString()
+        } else {
+            url
+        }
+
+        require(urlValidator.isValid(constructedUrl)) {
+            "Invalid url: $constructedUrl"
+        }
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder.startObject()
+                .startObject(HTTP_FIELD)
+                .field(SCHEME_FIELD, scheme)
+                .field(HOST_FIELD, host)
+                .field(PORT_FIELD, port)
+                .field(PATH_FIELD, path)
+                .field(PARAMS_FIELD, this.params)
+                .field(URL_FIELD, url)
+                .field(CONNECTION_TIMEOUT_FIELD, connection_timeout)
+                .field(SOCKET_TIMEOUT_FIELD, socket_timeout)
+                .endObject()
+                .endObject()
+    }
+
+    override fun name(): String {
+        return HTTP_FIELD
+    }
+
+    companion object {
+        const val SCHEME_FIELD = "scheme"
+        const val HOST_FIELD = "host"
+        const val PORT_FIELD = "port"
+        const val PATH_FIELD = "path"
+        const val PARAMS_FIELD = "params"
+        const val URL_FIELD = "url"
+        const val CONNECTION_TIMEOUT_FIELD = "connection_timeout"
+        const val SOCKET_TIMEOUT_FIELD = "socket_timeout"
+        const val HTTP_FIELD = "http"
+
+        val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(Input::class.java, ParseField("http"), CheckedFunction { parseInner(it) })
+
+        /**
+         * This parse function uses [XContentParser] to parse JSON input and store corresponding fields to create a [HttpInput] object
+         */
+        @JvmStatic @Throws(IOException::class)
+        private fun parseInner(xcp: XContentParser): HttpInput {
+            var scheme = "http"
+            var host: String? = null
+            var port: Int = -1
+            var path: String? = null
+            var params: Map<String, String> = mutableMapOf()
+            var url = ""
+            var connectionTimeout = TimeValue.timeValueSeconds(10).millis().toInt()
+            var socketTimeout = TimeValue.timeValueSeconds(10).millis().toInt()
+
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
+
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+                when (fieldName) {
+                    SCHEME_FIELD -> scheme = xcp.text()
+                    HOST_FIELD -> host = xcp.text()
+                    PORT_FIELD -> port = xcp.intValue()
+                    PATH_FIELD -> path = xcp.text()
+                    PARAMS_FIELD -> params = xcp.mapStrings()
+                    URL_FIELD -> url = xcp.text()
+                    CONNECTION_TIMEOUT_FIELD -> connectionTimeout = xcp.intValue()
+                    SOCKET_TIMEOUT_FIELD -> socketTimeout = xcp.intValue()
+                }
+            }
+            return HttpInput(scheme, host, port, path, params, url, connectionTimeout, socketTimeout)
+        }
+    }
+}

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -70,13 +70,6 @@ data class HttpInput(
             URIBuilder(url).build()
         }
 
-        // Make sure that when host is "localhost", only port 9200 is allowed.
-        if (constructedUrl.host == "localhost") {
-            require(constructedUrl.port == 9200) {
-                "Host: ${constructedUrl.host} is restricted to port 9200."
-            }
-        }
-
         require(urlValidator.isValid(constructedUrl.toString())) {
             "Invalid url: $constructedUrl"
         }

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInput.kt
@@ -32,9 +32,9 @@ import java.io.IOException
  */
 data class HttpInput(
     val scheme: String,
-    val host: String?,
+    val host: String,
     val port: Int,
-    val path: String?,
+    val path: String,
     val params: Map<String, String>,
     val url: String,
     val connection_timeout: Int,
@@ -113,9 +113,9 @@ data class HttpInput(
         @JvmStatic @Throws(IOException::class)
         private fun parseInner(xcp: XContentParser): HttpInput {
             var scheme = "http"
-            var host: String? = null
+            var host = ""
             var port: Int = -1
-            var path: String? = null
+            var path = ""
             var params: Map<String, String> = mutableMapOf()
             var url = ""
             var connectionTimeout = 5
@@ -146,7 +146,7 @@ data class HttpInput(
      */
     private fun validateFields(): Boolean {
         if (url.isNotEmpty()) {
-            return (Strings.isNullOrEmpty(host) && (port == -1) && path.isNullOrEmpty() && params.isEmpty())
+            return (host.isEmpty() && (port == -1) && path.isEmpty() && params.isEmpty())
         }
         return true
     }

--- a/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
+++ b/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
@@ -1,0 +1,99 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.core.model
+
+import org.junit.Assert
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class HttpInputTest {
+    // Test invalid url with different format in one function
+    @Test
+    fun `test invalid urls`() {
+        try {
+            // Invalid scheme
+            HttpInput("notAValidScheme", "localhost", 9200, "_cluster/health", mapOf(), "", 5000, 5000)
+            fail("Invalid scheme when creating HttpInput should fail.")
+        } catch (e: IllegalArgumentException) {
+            Assert.assertEquals("Invalid url: notAValidScheme://localhost:9200/_cluster/health", e.message)
+        }
+        try {
+            // Invalid host
+            HttpInput("http", "loco//host", 9200, "_cluster/health", mapOf(), "", 5000, 5000)
+            fail("Invalid host when creating HttpInput should fail.")
+        } catch (e: IllegalArgumentException) {
+            Assert.assertEquals("Invalid url: http://loco//host:9200/_cluster/health", e.message)
+        }
+        try {
+            // Invalid path
+            HttpInput("http", "localhost", 9200, "///", mapOf(), "", 5000, 5000)
+            fail("Invalid path when creating HttpInput should fail.")
+        } catch (e: IllegalArgumentException) {
+            Assert.assertEquals("Invalid url: http://localhost:9200///", e.message)
+        }
+        try {
+            // Invalid url
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", 5000, 5000)
+            fail("Invalid url when creating HttpInput should fail.")
+        } catch (e: IllegalArgumentException) {
+            Assert.assertEquals("Invalid url: ¯¯\\_( ͡° ͜ʖ ͡°)_//¯ ", e.message)
+        }
+        try {
+            // Invalid connection timeout
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", -5000, 5000)
+            fail("Invalid connection timeout when creating HttpInput should fail.")
+        } catch (e: IllegalArgumentException) {
+            Assert.assertEquals("Connection timeout: -5000 is not greater than 0.", e.message)
+        }
+        try {
+            // Invalid socket timeout
+            HttpInput("http", "localhost", 9200, "_cluster/health", mapOf(), "", 5000, -5000)
+            fail("Invalid socket timeout when creating HttpInput should fail.")
+        } catch (e: IllegalArgumentException) {
+            Assert.assertEquals("Socket timeout: -5000 is not greater than 0.", e.message)
+        }
+    }
+
+    // Test valid url with complete url
+    @Test
+    fun `test valid HttpInput using url`() {
+        val validHttpInput = HttpInput("", "", -1, "", mapOf(), "http://localhost:9200/_cluster/health/", 5000, 5000)
+        assertEquals(validHttpInput.url, "http://localhost:9200/_cluster/health/")
+        assertEquals(validHttpInput.connection_timeout, 5000)
+        assertEquals(validHttpInput.socket_timeout, 5000)
+    }
+
+    @Test
+    fun `test valid HttpInput created field by field`() {
+        val validHttpInput = HttpInput(
+                scheme = "http",
+                host = "localhost",
+                port = 9200,
+                path = "_cluster/health",
+                params = mapOf("value" to "x", "secondVal" to "second"),
+                url = "",
+                connection_timeout = 5000,
+                socket_timeout = 2500)
+        assertEquals(validHttpInput.scheme, "http")
+        assertEquals(validHttpInput.host, "localhost")
+        assertEquals(validHttpInput.port, 9200)
+        assertEquals(validHttpInput.path, "_cluster/health")
+        assertEquals(validHttpInput.params, mapOf("value" to "x", "secondVal" to "second"))
+        assertEquals(validHttpInput.connection_timeout, 5000)
+        assertEquals(validHttpInput.socket_timeout, 2500)
+    }
+}

--- a/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
+++ b/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/HttpInputTest.kt
@@ -74,12 +74,6 @@ class HttpInputTest {
         } catch (e: IllegalArgumentException) {
             assertEquals("Either one of url or scheme + host + port+ + path + params can be set.", e.message)
         }
-        try {
-            HttpInput("http", "localhost", 30678, "_cluster/health", mapOf(), "", 5, 5)
-            fail("localhost with invalid port number should fail.")
-        } catch (e: IllegalArgumentException) {
-            assertEquals("Host: localhost is restricted to port 9200.", e.message)
-        }
     }
 
     // Test valid url with complete url


### PR DESCRIPTION
*Issue #, if available: #47 

*Description of changes: 

- Adding new type of input ```HttpInput``` for monitors. 

```MonitorRunner``` class creates a ```HttpInputClient``` when collecting input results of an ```HttpInput```. 

- Changes to ```README``` file regarding setting ```JAVA_HOME```.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

```
> > Configure project :alerting
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.2.1
  OS Info               : Mac OS X 10.14.5 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12.0.1 [Java HotSpot(TM) 64-Bit Server VM 12.0.1+12])
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-12.0.1.jdk/Contents/Home
  Random Testing Seed   : 9087A73AD72ABD1
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 49s
52 actionable tasks: 30 executed, 22 up-to-date
```