### PR TITLE
fix integTestRunner build task

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -115,7 +115,7 @@ integTestRunner {
 
     // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
     if (System.getProperty("test.debug") != null) {
-        jvmArg '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
     }
 }
 


### PR DESCRIPTION
`./gradlew -Dtest.debug :alerting:integTest` will fail, the error message shows
`Could not find method jvmArg() for arguments [-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005] on task ':alerting:integTestRunner' of type org.gradle.api.tasks.testing.Test.`

*Description of changes:*
Change `jvmArg` to `jvmArgs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
