### PR TITLE
Don't allow interval to be set with 0 or negative values.

### DIFF
--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/Schedule.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/Schedule.kt
@@ -249,6 +249,10 @@ data class IntervalSchedule(
         if (!SUPPORTED_UNIT.contains(unit)) {
             throw IllegalArgumentException("Timezone $unit is not supported expected $SUPPORTED_UNIT")
         }
+
+        if (interval <= 0) {
+            throw IllegalArgumentException("Interval is not allowed to be 0 or negative")
+        }
     }
 
     @Transient

--- a/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/ScheduleTest.kt
+++ b/core/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/model/ScheduleTest.kt
@@ -336,5 +336,9 @@ class ScheduleTest : XContentTestBase {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
             IntervalSchedule(1, ChronoUnit.MONTHS)
         }
+
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
+            IntervalSchedule(-1, ChronoUnit.MINUTES)
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* Issue #37 

*Description of changes:*
Added logic to check if interval is less than or equal to 0, throw IllegalArgumentException if so.
Added test case to check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
