### PR TITLE
Execute monitor upon indexing & various fixes.

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -104,7 +104,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, P
     ): List<RestHandler> {
         return listOf(RestGetMonitorAction(settings, restController),
                 RestDeleteMonitorAction(settings, restController),
-                RestIndexMonitorAction(settings, restController, scheduledJobIndices, clusterService),
+                RestIndexMonitorAction(settings, restController, scheduledJobIndices, clusterService, runner),
                 RestSearchMonitorAction(settings, restController),
                 RestExecuteMonitorAction(settings, restController, runner),
                 RestAcknowledgeAlertAction(settings, restController),

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -289,8 +289,6 @@ class MonitorRunner(
                         XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, searchSource).use {
                             searchRequest.source(SearchSourceBuilder.fromXContent(it))
                         }
-                        logger.info("About to run search")
-                        logger.info("User is: ${client.threadPool().threadContext.getTransient<Any>("_opendistro_security_user")}")
                         val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
                         results += searchResponse.convertToMap()
                     }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -289,6 +289,8 @@ class MonitorRunner(
                         XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, searchSource).use {
                             searchRequest.source(SearchSourceBuilder.fromXContent(it))
                         }
+                        logger.info("About to run search")
+                        logger.info("User is: ${client.threadPool().threadContext.getTransient<Any>("_opendistro_security_user")}")
                         val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
                         results += searchResponse.convertToMap()
                     }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -186,7 +186,7 @@ class RestIndexMonitorAction(
          * If this is an update request we can simply update the monitor. Otherwise we first check to see how many monitors already exist,
          * and compare this to the [maxMonitorCount]. Requests that breach this threshold will be rejected.
          */
-        fun prepareMonitorIndexing() {
+        private fun prepareMonitorIndexing() {
             validateActionThrottle(newMonitor, maxActionThrottle, TimeValue.timeValueMinutes(1))
             if (channel.request().method() == PUT) return updateMonitor()
             val query = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("${Monitor.MONITOR_TYPE}.type", Monitor.MONITOR_TYPE))

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
 import org.elasticsearch.common.xcontent.NamedXContentRegistry
 import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.rest.action.RestActionListener
 
 class IndexUtils {
 
@@ -102,7 +103,7 @@ class IndexUtils {
 
             val indexMapping = index.mapping().sourceAsMap()
             if (indexMapping.containsKey(_META) && indexMapping[_META] is HashMap<*, *>) {
-                val metaData = indexMapping[_META] as HashMap<*, *>
+                val metaData = indexMapping[_META] as HashMap<String, *>
                 if (metaData.containsKey(SCHEMA_VERSION)) {
                     oldVersion = metaData[SCHEMA_VERSION] as Int
                 }
@@ -117,7 +118,7 @@ class IndexUtils {
             mapping: String,
             clusterState: ClusterState,
             client: IndicesAdminClient,
-            actionListener: ActionListener<AcknowledgedResponse>
+            actionListener: RestActionListener<AcknowledgedResponse>
         ) {
             if (clusterState.metaData.indices.containsKey(index)) {
                 if (shouldUpdateIndex(clusterState.metaData.indices[index], mapping)) {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
@@ -17,7 +17,6 @@ package com.amazon.opendistroforelasticsearch.alerting.util
 
 import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertIndices
 import com.amazon.opendistroforelasticsearch.alerting.core.ScheduledJobIndices
-import org.elasticsearch.action.ActionListener
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.IndicesAdminClient

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
@@ -133,7 +133,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test create monitor with no index error`() {
-        // use a non-existent index to trigger an input error
+        // use a non-existent index to fail monitor creation
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
 
         assertFailsWith(ResponseException::class, "Expected IndexNotFoundException") {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -454,8 +454,6 @@ class MonitorRestApiIT : AlertingRestTestCase() {
 
         val alerts = searchAlerts(monitor)
         val allAlerts = searchAlerts(monitor, AlertIndices.ALL_INDEX_PATTERN)
-        logger.info("All alerts: $allAlerts")
-        logger.info("Monitor : $monitor")
         // We have two alerts from above, 1 for each trigger, there should be only 1 left in active index
         assertEquals("One alert should be in active index", 1, alerts.size)
         assertEquals("Wrong alert in active index", alertKeep, alerts.single())

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -453,6 +453,9 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         Thread.sleep(5000)
 
         val alerts = searchAlerts(monitor)
+        val allAlerts = searchAlerts(monitor, AlertIndices.ALL_INDEX_PATTERN)
+        logger.info("All alerts: $allAlerts")
+        logger.info("Monitor : $monitor")
         // We have two alerts from above, 1 for each trigger, there should be only 1 left in active index
         assertEquals("One alert should be in active index", 1, alerts.size)
         assertEquals("Wrong alert in active index", alertKeep, alerts.single())

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
@@ -53,6 +53,20 @@ class ScheduledJobIndices(private val client: AdminClient, private val clusterSe
         }
     }
 
+    /**
+     * Initialize the indices required for scheduled jobs.
+     * First check if the index exists, and if not create the index with the provided callback listeners.
+     *
+     * @param actionListener A callback listener for the index creation call. Generally in the form of onSuccess, onFailure
+     */
+    fun initScheduledJobIndex(actionListener: ActionListener<CreateIndexResponse>) {
+        if (!scheduledJobIndexExists()) {
+            var indexRequest = CreateIndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
+                    .mapping(ScheduledJob.SCHEDULED_JOB_TYPE, scheduledJobMappings(), XContentType.JSON)
+            client.indices().create(indexRequest, actionListener)
+        }
+    }
+
     fun scheduledJobIndexExists(): Boolean {
         val clusterState = clusterService.state()
         return clusterState.routingTable.hasIndex(ScheduledJob.SCHEDULED_JOBS_INDEX)

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
@@ -16,7 +16,6 @@
 package com.amazon.opendistroforelasticsearch.alerting.core
 
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
-import org.elasticsearch.action.ActionListener
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse
 import org.elasticsearch.client.AdminClient
@@ -46,20 +45,6 @@ class ScheduledJobIndices(private val client: AdminClient, private val clusterSe
      * @param actionListener A callback listener for the index creation call. Generally in the form of onSuccess, onFailure
      */
     fun initScheduledJobIndex(actionListener: RestActionListener<CreateIndexResponse>) {
-        if (!scheduledJobIndexExists()) {
-            var indexRequest = CreateIndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
-                    .mapping(ScheduledJob.SCHEDULED_JOB_TYPE, scheduledJobMappings(), XContentType.JSON)
-            client.indices().create(indexRequest, actionListener)
-        }
-    }
-
-    /**
-     * Initialize the indices required for scheduled jobs.
-     * First check if the index exists, and if not create the index with the provided callback listeners.
-     *
-     * @param actionListener A callback listener for the index creation call. Generally in the form of onSuccess, onFailure
-     */
-    fun initScheduledJobIndex(actionListener: ActionListener<CreateIndexResponse>) {
         if (!scheduledJobIndexExists()) {
             var indexRequest = CreateIndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
                     .mapping(ScheduledJob.SCHEDULED_JOB_TYPE, scheduledJobMappings(), XContentType.JSON)

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
@@ -23,6 +23,7 @@ import org.elasticsearch.client.AdminClient
 import org.elasticsearch.cluster.health.ClusterIndexHealth
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.rest.action.RestActionListener
 
 /**
  * Initialize the Elasticsearch components required to run [ScheduledJobs].
@@ -44,7 +45,7 @@ class ScheduledJobIndices(private val client: AdminClient, private val clusterSe
      *
      * @param actionListener A callback listener for the index creation call. Generally in the form of onSuccess, onFailure
      */
-    fun initScheduledJobIndex(actionListener: ActionListener<CreateIndexResponse>) {
+    fun initScheduledJobIndex(actionListener: RestActionListener<CreateIndexResponse>) {
         if (!scheduledJobIndexExists()) {
             var indexRequest = CreateIndexRequest(ScheduledJob.SCHEDULED_JOBS_INDEX)
                     .mapping(ScheduledJob.SCHEDULED_JOB_TYPE, scheduledJobMappings(), XContentType.JSON)

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
@@ -38,6 +38,10 @@ import java.time.Instant
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.ThreadContextElement
+import org.elasticsearch.common.util.concurrent.ThreadContext
+import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext
+import kotlin.coroutines.CoroutineContext
 
 /** Convert an object to maps and lists representation */
 fun ToXContent.convertToMap(): Map<String, Any> {
@@ -145,3 +149,32 @@ suspend fun <C : ElasticsearchClient, T> C.suspendUntil(block: C.(ActionListener
             override fun onFailure(e: Exception) = cont.resumeWithException(e)
         })
     }
+
+/**
+ * Store a [ThreadContext] and restore a [ThreadContext] when the coroutine resumes on a different thread.
+ *
+ * @param threadContext - The context to store when switching to a coroutine.
+ * @param initialContext - The old context to restore upon completion of the coroutine.
+ */
+class ElasticThreadContextElement(
+    private val threadContext: ThreadContext
+) : ThreadContextElement<StoredContext> {
+
+    companion object Key : CoroutineContext.Key<ElasticThreadContextElement>
+    private var initialContext: StoredContext? = threadContext.newStoredContext(true)
+
+    override val key: CoroutineContext.Key<*>
+        get() = Key
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: StoredContext) {
+        initialContext = threadContext.stashContext()
+    }
+
+    override fun updateThreadContext(context: CoroutineContext): StoredContext {
+        if (initialContext != null) {
+            initialContext!!.close()
+            initialContext = null
+        }
+        return threadContext.newRestorableContext(true).get()
+    }
+}

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
@@ -153,28 +153,19 @@ suspend fun <C : ElasticsearchClient, T> C.suspendUntil(block: C.(ActionListener
 /**
  * Store a [ThreadContext] and restore a [ThreadContext] when the coroutine resumes on a different thread.
  *
- * @param threadContext - The context to store when switching to a coroutine.
- * @param initialContext - The old context to restore upon completion of the coroutine.
+ * @param threadContext - a [ThreadContext] instance
  */
-class ElasticThreadContextElement(
-    private val threadContext: ThreadContext
-) : ThreadContextElement<StoredContext> {
+class ElasticThreadContextElement(private val threadContext: ThreadContext) : ThreadContextElement<Unit> {
 
     companion object Key : CoroutineContext.Key<ElasticThreadContextElement>
-    private var initialContext: StoredContext? = threadContext.newStoredContext(true)
+    private var initialContext: StoredContext = threadContext.newStoredContext(true)
 
     override val key: CoroutineContext.Key<*>
         get() = Key
 
-    override fun restoreThreadContext(context: CoroutineContext, oldState: StoredContext) {
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {
         initialContext = threadContext.stashContext()
     }
 
-    override fun updateThreadContext(context: CoroutineContext): StoredContext {
-        if (initialContext != null) {
-            initialContext!!.close()
-            initialContext = null
-        }
-        return threadContext.newRestorableContext(true).get()
-    }
+    override fun updateThreadContext(context: CoroutineContext) = initialContext.close()
 }


### PR DESCRIPTION
## Changes
1. Make index monitor execute monitor to check for no errors. (Don't allow users to create monitors that will error out on the first execution, in particular don't allow users to create monitors on data they do not have access to when `alerting` is used with `security`).
2. Use coroutines in index monitor.
3. Update tests to reflect this.
4. Port `ElasticThreadContextElement` to opendistro-1.1 and use a cleaner version.
5. Fix imports


## Build output
```
lucaswin$ ./gradlew clean

> Configure project :alerting
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.2.1
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12.0.2 [Java HotSpot(TM) 64-Bit Server VM 12.0.2+10])
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-12.0.2.jdk/Contents/Home
  Random Testing Seed   : C9B0BED24A3F3C54
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
4 actionable tasks: 4 executed
8c8590216cf4:alerting lucaswin$ ./gradlew build

> Configure project :alerting
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.2.1
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12.0.2 [Java HotSpot(TM) 64-Bit Server VM 12.0.2+10])
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-12.0.2.jdk/Contents/Home
  Random Testing Seed   : E620C62AE58F95A1
=======================================

> Task :alerting-notification:compileJava
Note: /Users/lucaswin/Desktop/github/alerting-backend/alerting/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/Notification.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :alerting:compileKotlin
w: /Users/lucaswin/Desktop/github/alerting-backend/alerting/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt: (105, 52): Unchecked cast: Any? to kotlin.collections.HashMap<String, *> /* = java.util.HashMap<String, *> */

> Task :alerting-notification:test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.easymock.cglib.core.ReflectUtils$1 (file:/Users/lucaswin/.gradle/caches/modules-2/files-2.1/org.easymock/easymock/4.0.1/26f1c39bd323b6ac7fe0c4c8e33bfdffcdde03a2/easymock-4.0.1.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.easymock.cglib.core.ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 20s
50 actionable tasks: 49 executed, 1 up-to-date
```


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
