### PR TITLE
Cleanup ElasticThreadContextElement.

### DIFF
--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
@@ -153,28 +153,19 @@ suspend fun <C : ElasticsearchClient, T> C.suspendUntil(block: C.(ActionListener
 /**
  * Store a [ThreadContext] and restore a [ThreadContext] when the coroutine resumes on a different thread.
  *
- * @param threadContext - The context to store when switching to a coroutine.
- * @param initialContext - The old context to restore upon completion of the coroutine.
+ * @param threadContext - a [ThreadContext] instance
  */
-class ElasticThreadContextElement(
-    private val threadContext: ThreadContext
-) : ThreadContextElement<StoredContext> {
+class ElasticThreadContextElement(private val threadContext: ThreadContext) : ThreadContextElement<Unit> {
 
     companion object Key : CoroutineContext.Key<ElasticThreadContextElement>
-    private var initialContext: StoredContext? = threadContext.newStoredContext(true)
+    private var initialContext: StoredContext = threadContext.newStoredContext(true)
 
     override val key: CoroutineContext.Key<*>
         get() = Key
 
-    override fun restoreThreadContext(context: CoroutineContext, oldState: StoredContext) {
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {
         initialContext = threadContext.stashContext()
     }
 
-    override fun updateThreadContext(context: CoroutineContext): StoredContext {
-        if (initialContext != null) {
-            initialContext!!.close()
-            initialContext = null
-        }
-        return threadContext.newRestorableContext(true).get()
-    }
+    override fun updateThreadContext(context: CoroutineContext) = initialContext.close()
 }

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
@@ -158,14 +158,14 @@ suspend fun <C : ElasticsearchClient, T> C.suspendUntil(block: C.(ActionListener
 class ElasticThreadContextElement(private val threadContext: ThreadContext) : ThreadContextElement<Unit> {
 
     companion object Key : CoroutineContext.Key<ElasticThreadContextElement>
-    private var initialContext: StoredContext = threadContext.newStoredContext(true)
+    private var context: StoredContext = threadContext.newStoredContext(true)
 
     override val key: CoroutineContext.Key<*>
         get() = Key
 
     override fun restoreThreadContext(context: CoroutineContext, oldState: Unit) {
-        initialContext = threadContext.stashContext()
+        this.context = threadContext.stashContext()
     }
 
-    override fun updateThreadContext(context: CoroutineContext) = initialContext.close()
+    override fun updateThreadContext(context: CoroutineContext) = this.context.close()
 }


### PR DESCRIPTION
Cleanup elastic thread context element

*Description of changes:*
Make ElasticThreadContextElement cleaner.

*Build output:*
```
alerting lucaswin$ ./gradlew build

> Configure project :alerting
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.5.1
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12.0.2 [Java HotSpot(TM) 64-Bit Server VM 12.0.2+10])
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-12.0.2.jdk/Contents/Home
  Random Testing Seed   : E658BDD928D35147
=======================================

> Task :alerting-notification:compileJava
Note: /Users/lucaswin/Desktop/github/alerting-backend/alerting/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/Notification.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :alerting-notification:test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.easymock.cglib.core.ReflectUtils$1 (file:/Users/lucaswin/.gradle/caches/modules-2/files-2.1/org.easymock/easymock/4.0.1/26f1c39bd323b6ac7fe0c4c8e33bfdffcdde03a2/easymock-4.0.1.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.easymock.cglib.core.ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.5.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3m 1s
50 actionable tasks: 49 executed, 1 up-to-date
```

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
