### PR TITLE
Add Mail destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ When trigger conditions are met, you can publish messages to the following desti
 * [Slack](https://slack.com/)
 * Custom webhook
 * [Amazon Chime](https://aws.amazon.com/chime/)
+* Mail
 
 Messages can be static strings, or you can use the [Mustache](https://mustache.github.io/mustache.5.html) templates to include contextual information.
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -39,6 +39,7 @@ import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestIndexMonit
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestSearchMonitorAction
 import com.amazon.opendistroforelasticsearch.alerting.script.TriggerScript
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
+import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationMailSettings
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportDeleteDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportIndexDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportDeleteMonitorAction
@@ -184,12 +185,12 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, P
                 AlertingSettings.ALERTING_MAX_MONITORS,
                 AlertingSettings.REQUEST_TIMEOUT,
                 AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
-                AlertingSettings.DESTINATION_MAIL_HOST,
-                AlertingSettings.DESTINATION_MAIL_PORT,
-                AlertingSettings.DESTINATION_MAIL_METHOD,
-                AlertingSettings.DESTINATION_MAIL_FROM,
-                AlertingSettings.DESTINATION_MAIL_USERNAME,
-                AlertingSettings.DESTINATION_MAIL_PASSWORD
+                DestinationMailSettings.DESTINATION_MAIL_HOST,
+                DestinationMailSettings.DESTINATION_MAIL_PORT,
+                DestinationMailSettings.DESTINATION_MAIL_METHOD,
+                DestinationMailSettings.DESTINATION_MAIL_FROM,
+                DestinationMailSettings.DESTINATION_MAIL_USERNAME,
+                DestinationMailSettings.DESTINATION_MAIL_PASSWORD
             )
     }
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -183,7 +183,14 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, P
                 AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD,
                 AlertingSettings.ALERTING_MAX_MONITORS,
                 AlertingSettings.REQUEST_TIMEOUT,
-                AlertingSettings.MAX_ACTION_THROTTLE_VALUE)
+                AlertingSettings.MAX_ACTION_THROTTLE_VALUE,
+                AlertingSettings.DESTINATION_MAIL_HOST,
+                AlertingSettings.DESTINATION_MAIL_PORT,
+                AlertingSettings.DESTINATION_MAIL_METHOD,
+                AlertingSettings.DESTINATION_MAIL_FROM,
+                AlertingSettings.DESTINATION_MAIL_USERNAME,
+                AlertingSettings.DESTINATION_MAIL_PASSWORD
+            )
     }
 
     override fun onIndexModule(indexModule: IndexModule) {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -95,7 +95,7 @@ import java.time.Instant
 import kotlin.coroutines.CoroutineContext
 
 class MonitorRunner(
-    settings: Settings,
+    private val settings: Settings,
     private val client: Client,
     private val threadPool: ThreadPool,
     private val scriptService: ScriptService,
@@ -433,7 +433,11 @@ class MonitorRunner(
             if (!dryrun) {
                 withContext(Dispatchers.IO) {
                     val destination = getDestinationInfo(action.destinationId)
-                    actionOutput[MESSAGE_ID] = destination.publish(actionOutput[SUBJECT], actionOutput[MESSAGE]!!)
+                    actionOutput[MESSAGE_ID] = destination.publish(
+                        settings.getAsSettings("opendistro_alerting.destination"),
+                        actionOutput[SUBJECT],
+                        actionOutput[MESSAGE]!!
+                    )
                 }
             }
             ActionRunResult(action.id, action.name, actionOutput, false, currentTime(), null)

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
@@ -26,7 +26,7 @@ import com.amazon.opendistroforelasticsearch.alerting.destination.response.Desti
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.convertToMap
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.instant
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.optionalTimeField
-import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
+import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings
 import com.amazon.opendistroforelasticsearch.alerting.util.DestinationType
 import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils.Companion.NO_SCHEMA_VERSION
 import org.apache.logging.log4j.LogManager
@@ -200,7 +200,7 @@ data class Destination(
     }
 
     @Throws(IOException::class)
-    fun publish(settings: Settings?, compiledSubject: String?, compiledMessage: String): String {
+    fun publish(DestinationSettings: DestinationSettings, compiledSubject: String?, compiledMessage: String): String {
         val destinationMessage: BaseMessage
         val responseContent: String
         val responseStatusCode: Int
@@ -232,14 +232,14 @@ data class Destination(
             }
             DestinationType.MAIL -> {
                 destinationMessage = MailMessage.Builder(name)
-                        .withHost(AlertingSettings.DESTINATION_MAIL_HOST.get(settings))
-                        .withPort(AlertingSettings.DESTINATION_MAIL_PORT.get(settings))
-                        .withMethod(AlertingSettings.DESTINATION_MAIL_METHOD.get(settings))
-                        .withFrom(AlertingSettings.DESTINATION_MAIL_FROM.get(settings))
+                        .withHost(DestinationSettings.mail.host)
+                        .withPort(DestinationSettings.mail.port)
+                        .withMethod(DestinationSettings.mail.method)
+                        .withFrom(DestinationSettings.mail.from)
                         .withRecipients(mail?.recipients)
                         .withSubject(compiledSubject)
-                        .withUserName(AlertingSettings.DESTINATION_MAIL_USERNAME.get(settings))
-                        .withPassword(AlertingSettings.DESTINATION_MAIL_PASSWORD.get(settings))
+                        .withUserName(DestinationSettings.mail.username)
+                        .withPassword(DestinationSettings.mail.password)
                         .withMessage(compiledMessage).build()
             }
             DestinationType.TEST_ACTION -> {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
@@ -20,7 +20,9 @@ import com.amazon.opendistroforelasticsearch.alerting.destination.message.BaseMe
 import com.amazon.opendistroforelasticsearch.alerting.destination.message.ChimeMessage
 import com.amazon.opendistroforelasticsearch.alerting.destination.message.CustomWebhookMessage
 import com.amazon.opendistroforelasticsearch.alerting.destination.message.SlackMessage
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.MailMessage
 import com.amazon.opendistroforelasticsearch.alerting.destination.response.DestinationHttpResponse
+import com.amazon.opendistroforelasticsearch.alerting.destination.response.DestinationMailResponse
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.convertToMap
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.instant
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.optionalTimeField
@@ -49,7 +51,8 @@ data class Destination(
     val lastUpdateTime: Instant,
     val chime: Chime?,
     val slack: Slack?,
-    val customWebhook: CustomWebhook?
+    val customWebhook: CustomWebhook?,
+    val mail: Mail?
 ) : ToXContent {
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -107,6 +110,8 @@ data class Destination(
         const val CHIME = "chime"
         const val SLACK = "slack"
         const val CUSTOMWEBHOOK = "custom_webhook"
+        const val MAIL = "mail"
+
         // This constant is used for test actions created part of integ tests
         const val TEST_ACTION = "test"
 
@@ -121,6 +126,7 @@ data class Destination(
             var slack: Slack? = null
             var chime: Chime? = null
             var customWebhook: CustomWebhook? = null
+            var mail: Mail? = null
             var lastUpdateTime: Instant? = null
             var schemaVersion = NO_SCHEMA_VERSION
 
@@ -148,6 +154,9 @@ data class Destination(
                     CUSTOMWEBHOOK -> {
                         customWebhook = CustomWebhook.parse(xcp)
                     }
+                    MAIL -> {
+                        mail = Mail.parse(xcp)
+                    }
                     TEST_ACTION -> {
                         // This condition is for integ tests to avoid parsing
                     }
@@ -167,7 +176,8 @@ data class Destination(
                     lastUpdateTime ?: Instant.now(),
                     chime,
                     slack,
-                    customWebhook)
+                    customWebhook,
+                    mail)
         }
 
         @JvmStatic
@@ -190,6 +200,8 @@ data class Destination(
     @Throws(IOException::class)
     fun publish(compiledSubject: String?, compiledMessage: String): String {
         val destinationMessage: BaseMessage
+        val responseContent: String
+        val responseStatusCode: Int
         when (type) {
             DestinationType.CHIME -> {
                 val messageContent = chime?.constructMessageContent(compiledSubject, compiledMessage)
@@ -216,13 +228,34 @@ data class Destination(
                         .withHeaderParams(customWebhook?.headerParams)
                         .withMessage(compiledMessage).build()
             }
+            DestinationType.MAIL -> {
+                destinationMessage = MailMessage.Builder(name)
+                        .withHost(mail?.host)
+                        .withPort(mail?.port)
+                        .withAuth(mail?.auth)
+                        .withMethod(mail?.method)
+                        .withFrom(mail?.from)
+                        .withRecipients(mail?.recipients)
+                        .withSubject(compiledSubject)
+                        .withUserName(mail?.username)
+                        .withPassword(mail?.password)
+                        .withMessage(compiledMessage).build()
+            }
             DestinationType.TEST_ACTION -> {
                 return "test action"
             }
         }
-        val response = Notification.publish(destinationMessage) as DestinationHttpResponse
-        logger.info("Message published for action name: $name, messageid: ${response.responseContent}, statuscode: ${response.statusCode}")
-        return response.responseContent
+        if (type == DestinationType.MAIL) {
+            val response = Notification.publish(destinationMessage) as DestinationMailResponse
+            responseContent = response.responseContent
+            responseStatusCode = response.statusCode
+        } else {
+            val response = Notification.publish(destinationMessage) as DestinationHttpResponse
+            responseContent = response.responseContent
+            responseStatusCode = response.statusCode
+        }
+        logger.info("Message published for action name: $name, messageid: $responseContent, statuscode: $responseStatusCode")
+        return responseContent
     }
 
     fun constructResponseForDestinationType(type: DestinationType): Any {
@@ -231,6 +264,7 @@ data class Destination(
             DestinationType.CHIME -> content = chime?.convertToMap()?.get(type.value)
             DestinationType.SLACK -> content = slack?.convertToMap()?.get(type.value)
             DestinationType.CUSTOM_WEBHOOK -> content = customWebhook?.convertToMap()?.get(type.value)
+            DestinationType.MAIL -> content = mail?.convertToMap()?.get(type.value)
             DestinationType.TEST_ACTION -> content = "dummy"
         }
         if (content == null) {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
@@ -32,7 +32,6 @@ import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils.Companion.
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
-import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentParser
@@ -96,6 +95,12 @@ data class Destination(
         if (customWebhook != null) {
             out.writeBoolean(true)
             customWebhook.writeTo(out)
+        } else {
+            out.writeBoolean(false)
+        }
+        if (mail != null) {
+            out.writeBoolean(true)
+            mail.writeTo(out)
         } else {
             out.writeBoolean(false)
         }
@@ -194,7 +199,8 @@ data class Destination(
                 sin.readInstant(), // lastUpdateTime
                 Chime.readFrom(sin), // chime
                 Slack.readFrom(sin), // slack
-                CustomWebhook.readFrom(sin) // customWebhook
+                CustomWebhook.readFrom(sin), // customWebhook
+                Mail.readFrom(sin) // mail
             )
         }
     }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
@@ -26,11 +26,13 @@ import com.amazon.opendistroforelasticsearch.alerting.destination.response.Desti
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.convertToMap
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.instant
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.optionalTimeField
+import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
 import com.amazon.opendistroforelasticsearch.alerting.util.DestinationType
 import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils.Companion.NO_SCHEMA_VERSION
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentParser
@@ -198,7 +200,7 @@ data class Destination(
     }
 
     @Throws(IOException::class)
-    fun publish(compiledSubject: String?, compiledMessage: String): String {
+    fun publish(settings: Settings?, compiledSubject: String?, compiledMessage: String): String {
         val destinationMessage: BaseMessage
         val responseContent: String
         val responseStatusCode: Int
@@ -230,15 +232,14 @@ data class Destination(
             }
             DestinationType.MAIL -> {
                 destinationMessage = MailMessage.Builder(name)
-                        .withHost(mail?.host)
-                        .withPort(mail?.port)
-                        .withAuth(mail?.auth)
-                        .withMethod(mail?.method)
-                        .withFrom(mail?.from)
+                        .withHost(AlertingSettings.DESTINATION_MAIL_HOST.get(settings))
+                        .withPort(AlertingSettings.DESTINATION_MAIL_PORT.get(settings))
+                        .withMethod(AlertingSettings.DESTINATION_MAIL_METHOD.get(settings))
+                        .withFrom(AlertingSettings.DESTINATION_MAIL_FROM.get(settings))
                         .withRecipients(mail?.recipients)
                         .withSubject(compiledSubject)
-                        .withUserName(mail?.username)
-                        .withPassword(mail?.password)
+                        .withUserName(AlertingSettings.DESTINATION_MAIL_USERNAME.get(settings))
+                        .withPassword(AlertingSettings.DESTINATION_MAIL_PASSWORD.get(settings))
                         .withMessage(compiledMessage).build()
             }
             DestinationType.TEST_ACTION -> {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Mail.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Mail.kt
@@ -1,0 +1,115 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.model.destination
+
+import org.elasticsearch.common.Strings
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import java.io.IOException
+import java.lang.IllegalStateException
+
+/**
+ * A value object that represents a Mail message. Mail message will be
+ * submitted to the Mail destination
+ */
+data class Mail(
+    val host: String?,
+    val port: Int?,
+    val auth: Boolean?,
+    val method: String?,
+    val from: String?,
+    val recipients: String?,
+    val subject: String?,
+    val username: String?,
+    val password: String?
+) : ToXContent {
+
+    init {
+        require(!Strings.isNullOrEmpty(host)) {
+            "Host name must be provided."
+        }
+        require(!Strings.isNullOrEmpty(from)) {
+            "From address must be provided."
+        }
+        require(!Strings.isNullOrEmpty(recipients)) {
+            "Comma separated recipients must be provided."
+        }
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder.startObject(TYPE)
+                .field(HOST_FIELD, host)
+                .field(PORT_FIELD, port)
+                .field(AUTH_FIELD, auth)
+                .field(METHOD_FIELD, method)
+                .field(FROM_FIELD, from)
+                .field(RECIPIENTS_FIELD, recipients)
+                .field(SUBJECT_FIELD, subject)
+                .field(USERNAME_FIELD, username)
+                .field(PASSWORD_FIELD, password)
+                .endObject()
+    }
+
+    companion object {
+        const val TYPE = "mail"
+        const val HOST_FIELD = "host"
+        const val PORT_FIELD = "port"
+        const val AUTH_FIELD = "auth"
+        const val METHOD_FIELD = "method"
+        const val FROM_FIELD = "from"
+        const val RECIPIENTS_FIELD = "recipients"
+        const val SUBJECT_FIELD = "subject"
+        const val USERNAME_FIELD = "username"
+        const val PASSWORD_FIELD = "password"
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun parse(xcp: XContentParser): Mail {
+            var host: String? = null
+            var port: Int? = 25
+            var auth: Boolean? = false
+            var method: String? = "plain"
+            var from: String? = null
+            var recipients: String? = null
+            var subject: String? = null
+            var username: String? = null
+            var password: String? = null
+
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+                when (fieldName) {
+                    HOST_FIELD -> host = xcp.textOrNull()
+                    PORT_FIELD -> port = xcp.intValue()
+                    AUTH_FIELD -> auth = xcp.booleanValue()
+                    METHOD_FIELD -> method = xcp.textOrNull()
+                    FROM_FIELD -> from = xcp.textOrNull()
+                    RECIPIENTS_FIELD -> recipients = xcp.textOrNull()
+                    SUBJECT_FIELD -> subject = xcp.textOrNull()
+                    USERNAME_FIELD -> username = xcp.textOrNull()
+                    PASSWORD_FIELD -> password = xcp.textOrNull()
+                    else -> {
+                        throw IllegalStateException("Unexpected field: $fieldName, while parsing mail destination")
+                    }
+                }
+            }
+            return Mail(host, port, auth, method, from, recipients, subject, username, password)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Mail.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Mail.kt
@@ -28,24 +28,10 @@ import java.lang.IllegalStateException
  * submitted to the Mail destination
  */
 data class Mail(
-    val host: String?,
-    val port: Int?,
-    val auth: Boolean?,
-    val method: String?,
-    val from: String?,
-    val recipients: String?,
-    val subject: String?,
-    val username: String?,
-    val password: String?
+    val recipients: String?
 ) : ToXContent {
 
     init {
-        require(!Strings.isNullOrEmpty(host)) {
-            "Host name must be provided."
-        }
-        require(!Strings.isNullOrEmpty(from)) {
-            "From address must be provided."
-        }
         require(!Strings.isNullOrEmpty(recipients)) {
             "Comma separated recipients must be provided."
         }
@@ -53,63 +39,31 @@ data class Mail(
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject(TYPE)
-                .field(HOST_FIELD, host)
-                .field(PORT_FIELD, port)
-                .field(AUTH_FIELD, auth)
-                .field(METHOD_FIELD, method)
-                .field(FROM_FIELD, from)
                 .field(RECIPIENTS_FIELD, recipients)
-                .field(SUBJECT_FIELD, subject)
-                .field(USERNAME_FIELD, username)
-                .field(PASSWORD_FIELD, password)
                 .endObject()
     }
 
     companion object {
         const val TYPE = "mail"
-        const val HOST_FIELD = "host"
-        const val PORT_FIELD = "port"
-        const val AUTH_FIELD = "auth"
-        const val METHOD_FIELD = "method"
-        const val FROM_FIELD = "from"
         const val RECIPIENTS_FIELD = "recipients"
-        const val SUBJECT_FIELD = "subject"
-        const val USERNAME_FIELD = "username"
-        const val PASSWORD_FIELD = "password"
 
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser): Mail {
-            var host: String? = null
-            var port: Int? = 25
-            var auth: Boolean? = false
-            var method: String? = "plain"
-            var from: String? = null
             var recipients: String? = null
-            var subject: String? = null
-            var username: String? = null
-            var password: String? = null
 
             ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
                 val fieldName = xcp.currentName()
                 xcp.nextToken()
                 when (fieldName) {
-                    HOST_FIELD -> host = xcp.textOrNull()
-                    PORT_FIELD -> port = xcp.intValue()
-                    AUTH_FIELD -> auth = xcp.booleanValue()
-                    METHOD_FIELD -> method = xcp.textOrNull()
-                    FROM_FIELD -> from = xcp.textOrNull()
                     RECIPIENTS_FIELD -> recipients = xcp.textOrNull()
-                    SUBJECT_FIELD -> subject = xcp.textOrNull()
-                    USERNAME_FIELD -> username = xcp.textOrNull()
-                    PASSWORD_FIELD -> password = xcp.textOrNull()
                     else -> {
                         throw IllegalStateException("Unexpected field: $fieldName, while parsing mail destination")
                     }
                 }
             }
-            return Mail(host, port, auth, method, from, recipients, subject, username, password)
+            return Mail(recipients)
         }
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Mail.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Mail.kt
@@ -16,6 +16,8 @@
 package com.amazon.opendistroforelasticsearch.alerting.model.destination
 
 import org.elasticsearch.common.Strings
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentParser
@@ -43,6 +45,11 @@ data class Mail(
                 .endObject()
     }
 
+    @Throws(IOException::class)
+    fun writeTo(out: StreamOutput) {
+        out.writeString(recipients)
+    }
+
     companion object {
         const val TYPE = "mail"
         const val RECIPIENTS_FIELD = "recipients"
@@ -64,6 +71,16 @@ data class Mail(
                 }
             }
             return Mail(recipients)
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): Mail? {
+            return if (sin.readBoolean()) {
+                Mail(
+                    sin.readString() // recipients
+                )
+            } else null
         }
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
@@ -17,7 +17,6 @@ package com.amazon.opendistroforelasticsearch.alerting.settings
 
 import com.amazon.opendistroforelasticsearch.alerting.AlertingPlugin
 import org.elasticsearch.common.settings.Setting
-import org.elasticsearch.common.settings.SecureSetting
 import org.elasticsearch.common.unit.TimeValue
 import java.util.concurrent.TimeUnit
 
@@ -118,41 +117,6 @@ class AlertingSettings {
         val MAX_ACTION_THROTTLE_VALUE = Setting.positiveTimeSetting(
                 "opendistro.alerting.action_throttle_max_value",
                 TimeValue.timeValueHours(24),
-                Setting.Property.NodeScope, Setting.Property.Dynamic
-        )
-
-        val DESTINATION_MAIL_HOST = Setting.simpleString(
-                "opendistro.alerting.destination.mail.host",
-                "localhost",
-                Setting.Property.NodeScope, Setting.Property.Dynamic
-        )
-
-        val DESTINATION_MAIL_PORT = Setting.intSetting(
-                "opendistro.alerting.destination.mail.port",
-                25,
-                Setting.Property.NodeScope, Setting.Property.Dynamic
-        )
-
-        val DESTINATION_MAIL_METHOD = Setting.simpleString(
-                "opendistro.alerting.destination.mail.method",
-                "none",
-                Setting.Property.NodeScope, Setting.Property.Dynamic
-        )
-
-        val DESTINATION_MAIL_FROM = Setting.simpleString(
-                "opendistro.alerting.destination.mail.from",
-                "opendistro-alerting@localhost",
-                Setting.Property.NodeScope, Setting.Property.Dynamic
-        )
-
-        val DESTINATION_MAIL_USERNAME = SecureSetting.secureString(
-                "opendistro.alerting.destination.mail.username",
-                null
-        )
-
-        val DESTINATION_MAIL_PASSWORD = SecureSetting.secureString(
-                "opendistro.alerting.destination.mail.password",
-                null
-        )
+                Setting.Property.NodeScope, Setting.Property.Dynamic)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.alerting.settings
 
 import com.amazon.opendistroforelasticsearch.alerting.AlertingPlugin
 import org.elasticsearch.common.settings.Setting
+import org.elasticsearch.common.settings.SecureSetting
 import org.elasticsearch.common.unit.TimeValue
 import java.util.concurrent.TimeUnit
 
@@ -117,6 +118,41 @@ class AlertingSettings {
         val MAX_ACTION_THROTTLE_VALUE = Setting.positiveTimeSetting(
                 "opendistro.alerting.action_throttle_max_value",
                 TimeValue.timeValueHours(24),
-                Setting.Property.NodeScope, Setting.Property.Dynamic)
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_HOST = Setting.simpleString(
+                "opendistro.alerting.destination.mail.host",
+                "localhost",
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_PORT = Setting.intSetting(
+                "opendistro.alerting.destination.mail.port",
+                25,
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_METHOD = Setting.simpleString(
+                "opendistro.alerting.destination.mail.method",
+                "none",
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_FROM = Setting.simpleString(
+                "opendistro.alerting.destination.mail.from",
+                "opendistro-alerting@localhost",
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_USERNAME = SecureSetting.secureString(
+                "opendistro.alerting.destination.mail.username",
+                null
+        )
+
+        val DESTINATION_MAIL_PASSWORD = SecureSetting.secureString(
+                "opendistro.alerting.destination.mail.password",
+                null
+        )
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationMailSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationMailSettings.kt
@@ -21,25 +21,25 @@ data class DestinationMailSettings(
         val DESTINATION_MAIL_HOST = Setting.simpleString(
                 "opendistro.alerting.destination.mail.host",
                 "localhost",
-                Setting.Property.NodeScope, Setting.Property.Dynamic
+                Setting.Property.NodeScope
         )
 
         val DESTINATION_MAIL_PORT = Setting.intSetting(
                 "opendistro.alerting.destination.mail.port",
                 25,
-                Setting.Property.NodeScope, Setting.Property.Dynamic
+                Setting.Property.NodeScope
         )
 
         val DESTINATION_MAIL_METHOD = Setting.simpleString(
                 "opendistro.alerting.destination.mail.method",
                 "none",
-                Setting.Property.NodeScope, Setting.Property.Dynamic
+                Setting.Property.NodeScope
         )
 
         val DESTINATION_MAIL_FROM = Setting.simpleString(
                 "opendistro.alerting.destination.mail.from",
                 "opendistro-alerting@localhost",
-                Setting.Property.NodeScope, Setting.Property.Dynamic
+                Setting.Property.NodeScope
         )
 
         val DESTINATION_MAIL_USERNAME = SecureSetting.secureString(

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationMailSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationMailSettings.kt
@@ -1,0 +1,68 @@
+package com.amazon.opendistroforelasticsearch.alerting.settings
+
+import org.elasticsearch.common.settings.Setting
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.settings.SecureSetting
+import org.elasticsearch.common.settings.SecureString
+import java.io.IOException
+
+/**
+ * settings specific to mail destination.
+ */
+data class DestinationMailSettings(
+    val host: String,
+    val port: Int,
+    val method: String,
+    val from: String,
+    val username: SecureString,
+    val password: SecureString
+) {
+    companion object {
+        val DESTINATION_MAIL_HOST = Setting.simpleString(
+                "opendistro.alerting.destination.mail.host",
+                "localhost",
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_PORT = Setting.intSetting(
+                "opendistro.alerting.destination.mail.port",
+                25,
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_METHOD = Setting.simpleString(
+                "opendistro.alerting.destination.mail.method",
+                "none",
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_FROM = Setting.simpleString(
+                "opendistro.alerting.destination.mail.from",
+                "opendistro-alerting@localhost",
+                Setting.Property.NodeScope, Setting.Property.Dynamic
+        )
+
+        val DESTINATION_MAIL_USERNAME = SecureSetting.secureString(
+                "opendistro.alerting.destination.mail.username",
+                null
+        )
+
+        val DESTINATION_MAIL_PASSWORD = SecureSetting.secureString(
+                "opendistro.alerting.destination.mail.password",
+                null
+        )
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun parse(settings: Settings): DestinationMailSettings {
+            return DestinationMailSettings(
+                DESTINATION_MAIL_HOST.get(settings),
+                DESTINATION_MAIL_PORT.get(settings),
+                DESTINATION_MAIL_METHOD.get(settings),
+                DESTINATION_MAIL_FROM.get(settings),
+                DESTINATION_MAIL_USERNAME.get(settings),
+                DESTINATION_MAIL_PASSWORD.get(settings)
+            )
+        }
+    }
+}

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationMailSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationMailSettings.kt
@@ -20,7 +20,7 @@ data class DestinationMailSettings(
     companion object {
         val DESTINATION_MAIL_HOST = Setting.simpleString(
                 "opendistro.alerting.destination.mail.host",
-                "localhost",
+                "",
                 Setting.Property.NodeScope
         )
 
@@ -38,7 +38,7 @@ data class DestinationMailSettings(
 
         val DESTINATION_MAIL_FROM = Setting.simpleString(
                 "opendistro.alerting.destination.mail.from",
-                "opendistro-alerting@localhost",
+                "",
                 Setting.Property.NodeScope
         )
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/DestinationSettings.kt
@@ -1,0 +1,22 @@
+package com.amazon.opendistroforelasticsearch.alerting.settings
+
+import org.elasticsearch.common.settings.Settings
+import java.io.IOException
+
+/**
+ * settings specific to mail destination.
+ */
+data class DestinationSettings(
+    val mail: DestinationMailSettings
+) {
+    companion object {
+        @JvmStatic
+        @Throws(IOException::class)
+        fun parse(settings: Settings): DestinationSettings {
+            val prefix: (String) -> (Boolean) = { it.startsWith("opendistro.alerting.destination.mail") }
+            return DestinationSettings(
+                DestinationMailSettings.parse(settings.filter(prefix))
+            )
+        }
+    }
+}

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/DestinationType.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/DestinationType.kt
@@ -19,5 +19,6 @@ enum class DestinationType(val value: String) {
     CHIME("chime"),
     SLACK("slack"),
     CUSTOM_WEBHOOK("custom_webhook"),
+    MAIL("mail"),
     TEST_ACTION("test_action")
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -116,7 +116,8 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
                 lastUpdateTime = Instant.now(),
                 chime = null,
                 slack = null,
-                customWebhook = null)
+                customWebhook = null,
+                mail = null)
     }
 
     protected fun verifyIndexSchemaVersion(index: String, expectedVersion: Int) {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequestTests.kt
@@ -44,6 +44,7 @@ class IndexDestinationRequestTests : ESTestCase() {
                         Instant.now(),
                         Chime("test.com"),
                         null,
+                        null,
                         null
                 )
         )
@@ -78,6 +79,7 @@ class IndexDestinationRequestTests : ESTestCase() {
                         "TestChimeDest",
                         Instant.now(),
                         Chime("test.com"),
+                        null,
                         null,
                         null
                 )

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationResponseTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationResponseTests.kt
@@ -30,7 +30,7 @@ class IndexDestinationResponseTests : ESTestCase() {
 
         val req = IndexDestinationResponse("1234", 0L, 1L, 2L, RestStatus.CREATED,
                 Destination("1234", 0L, 1, DestinationType.CHIME, "TestChimeDest",
-                        Instant.now(), Chime("test.com"), null, null))
+                        Instant.now(), Chime("test.com"), null, null, null))
 
         assertNotNull(req)
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.alerting.model
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Chime
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.CustomWebhook
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Destination
+import com.amazon.opendistroforelasticsearch.alerting.model.destination.Mail
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Slack
 import com.amazon.opendistroforelasticsearch.alerting.util.DestinationType
 import org.elasticsearch.common.io.stream.BytesStreamOutput
@@ -49,6 +50,19 @@ class DestinationTests : ESTestCase() {
         try {
             Slack("")
             fail("Creating a slack destination with empty url did not fail.")
+        } catch (ignored: IllegalArgumentException) {
+        }
+    }
+
+    fun `test mail destination`() {
+        val mail = Mail("mail.abc", null, false, null, "test@abc.com", "test@abc.com", null, null, null)
+        assertEquals("Host is manipulated", mail.host, "mail.abc")
+    }
+
+    fun `test mail destination with out host`() {
+        try {
+            Mail("", null, false, null, "test@abc.com", "test@abc.com", null, null, null)
+            fail("Creating a mail destination with empty host did not fail.")
         } catch (ignored: IllegalArgumentException) {
         }
     }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
@@ -54,6 +54,11 @@ class DestinationTests : ESTestCase() {
         }
     }
 
+    fun `test mail destination`() {
+        val mail = Mail("test@localhost.localdomain")
+        assertEquals("Recipients is manipulated", mail.recipients, "test@localhost.localdomain")
+    }
+
     fun `test mail destination without recipient`() {
         try {
             Mail("")
@@ -91,7 +96,7 @@ class DestinationTests : ESTestCase() {
 
     fun `test chime destination create using stream`() {
         val chimeDest = Destination("1234", 0L, 1, DestinationType.CHIME, "TestChimeDest",
-                Instant.now(), Chime("test.com"), null, null)
+                Instant.now(), Chime("test.com"), null, null, null)
 
         val out = BytesStreamOutput()
         chimeDest.writeTo(out)
@@ -108,11 +113,12 @@ class DestinationTests : ESTestCase() {
         assertNotNull(newDest.chime)
         assertNull(newDest.slack)
         assertNull(newDest.customWebhook)
+        assertNull(newDest.mail)
     }
 
     fun `test slack destination create using stream`() {
         val chimeDest = Destination("2345", 1L, 2, DestinationType.SLACK, "TestSlackDest",
-                Instant.now(), null, Slack("mytest.com"), null)
+                Instant.now(), null, Slack("mytest.com"), null, null)
 
         val out = BytesStreamOutput()
         chimeDest.writeTo(out)
@@ -129,6 +135,7 @@ class DestinationTests : ESTestCase() {
         assertNull(newDest.chime)
         assertNotNull(newDest.slack)
         assertNull(newDest.customWebhook)
+        assertNull(newDest.mail)
     }
 
     fun `test customwebhook destination create using stream`() {
@@ -151,7 +158,8 @@ class DestinationTests : ESTestCase() {
                     mutableMapOf(),
                     "admin",
                     "admin"
-                )
+                ),
+                null
         )
         val out = BytesStreamOutput()
         chimeDest.writeTo(out)
@@ -168,6 +176,7 @@ class DestinationTests : ESTestCase() {
         assertNull(newDest.chime)
         assertNull(newDest.slack)
         assertNotNull(newDest.customWebhook)
+        assertNull(newDest.mail)
     }
 
     fun `test customwebhook destination create using stream with optionals`() {
@@ -190,7 +199,8 @@ class DestinationTests : ESTestCase() {
                         mutableMapOf(),
                         null,
                         null
-                )
+                ),
+                null
         )
         val out = BytesStreamOutput()
         chimeDest.writeTo(out)
@@ -207,5 +217,28 @@ class DestinationTests : ESTestCase() {
         assertNull(newDest.chime)
         assertNull(newDest.slack)
         assertNotNull(newDest.customWebhook)
+        assertNull(newDest.mail)
+    }
+
+    fun `test mail destination create using stream`() {
+        val mailDest = Destination("2345", 1L, 2, DestinationType.MAIL, "TestMailDest",
+                Instant.now(), null, null, null, Mail("test@localhost.localdomain"))
+
+        val out = BytesStreamOutput()
+        mailDest.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newDest = Destination.readFrom(sin)
+
+        assertNotNull(newDest)
+        assertEquals("2345", newDest.id)
+        assertEquals(1, newDest.version)
+        assertEquals(2, newDest.schemaVersion)
+        assertEquals(DestinationType.MAIL, newDest.type)
+        assertEquals("TestMailDest", newDest.name)
+        assertNotNull(newDest.lastUpdateTime)
+        assertNull(newDest.chime)
+        assertNull(newDest.slack)
+        assertNull(newDest.customWebhook)
+        assertNotNull(newDest.mail)
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
@@ -54,15 +54,10 @@ class DestinationTests : ESTestCase() {
         }
     }
 
-    fun `test mail destination`() {
-        val mail = Mail("mail.abc", null, false, null, "test@abc.com", "test@abc.com", null, null, null)
-        assertEquals("Host is manipulated", mail.host, "mail.abc")
-    }
-
-    fun `test mail destination with out host`() {
+    fun `test mail destination without recipient`() {
         try {
-            Mail("", null, false, null, "test@abc.com", "test@abc.com", null, null, null)
-            fail("Creating a mail destination with empty host did not fail.")
+            Mail("")
+            fail("Creating a mail destination with empty recipient did not fail.")
         } catch (ignored: IllegalArgumentException) {
         }
     }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -40,7 +40,8 @@ class DestinationRestApiIT : AlertingRestTestCase() {
                 lastUpdateTime = Instant.now(),
                 chime = chime,
                 slack = null,
-                customWebhook = null)
+                customWebhook = null,
+                mail = null)
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CHIME)
@@ -70,7 +71,8 @@ class DestinationRestApiIT : AlertingRestTestCase() {
                 lastUpdateTime = Instant.now(),
                 chime = null,
                 slack = slack,
-                customWebhook = null)
+                customWebhook = null,
+                mail = null)
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.SLACK)
@@ -100,7 +102,8 @@ class DestinationRestApiIT : AlertingRestTestCase() {
                 lastUpdateTime = Instant.now(),
                 chime = null,
                 slack = null,
-                customWebhook = customWebhook)
+                customWebhook = customWebhook,
+                mail = null)
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CUSTOM_WEBHOOK)
@@ -116,7 +119,8 @@ class DestinationRestApiIT : AlertingRestTestCase() {
                 lastUpdateTime = Instant.now(),
                 chime = null,
                 slack = null,
-                customWebhook = customWebhook)
+                customWebhook = customWebhook,
+                mail = null)
         val createdDestination = createDestination(destination = destination)
         assertEquals("Incorrect destination name", createdDestination.name, "test")
         assertEquals("Incorrect destination type", createdDestination.type, DestinationType.CUSTOM_WEBHOOK)

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/DestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/DestinationRestApiIT.kt
@@ -21,6 +21,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.destination.Chime
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.CustomWebhook
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Destination
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Slack
+import com.amazon.opendistroforelasticsearch.alerting.model.destination.Mail
 import com.amazon.opendistroforelasticsearch.alerting.makeRequest
 import com.amazon.opendistroforelasticsearch.alerting.util.DestinationType
 import org.elasticsearch.rest.RestStatus
@@ -151,6 +152,37 @@ class DestinationRestApiIT : AlertingRestTestCase() {
                 destination.copy(name = "updatedName", customWebhook = updatedCustomWebhook,
                         type = DestinationType.CUSTOM_WEBHOOK))
         assertEquals("Incorrect destination url after update", "abc.com", updatedDestination.customWebhook?.host)
+    }
+
+    fun `test creating a mail destination`() {
+        val mail = Mail("test@localhost.localdomain")
+        val destination = Destination(
+                type = DestinationType.MAIL,
+                name = "test",
+                lastUpdateTime = Instant.now(),
+                chime = null,
+                slack = null,
+                customWebhook = null,
+                mail = mail)
+        val createdDestination = createDestination(destination = destination)
+        assertEquals("Incorrect destination name", createdDestination.name, "test")
+        assertEquals("Incorrect destination type", createdDestination.type, DestinationType.MAIL)
+        Assert.assertNotNull("mail object should not be null", createdDestination.mail)
+    }
+
+    fun `test updating a mail destination`() {
+        val destination = createDestination()
+        val mail = Mail("updated@localhost.localdomain")
+        var updatedDestination = updateDestination(
+                destination.copy(name = "updatedName", mail = mail, type = DestinationType.MAIL))
+        assertEquals("Incorrect destination name after update", updatedDestination.name, "updatedName")
+        assertEquals("Incorrect destination ID after update", updatedDestination.id, destination.id)
+        assertEquals("Incorrect destination type after update", updatedDestination.type, DestinationType.MAIL)
+        assertEquals("Incorrect destination url after update", "updated@localhost.localdomain", updatedDestination.mail?.recipients)
+        val updatedMail = Mail("updated2@localhost.localdomain")
+        updatedDestination = updateDestination(
+                destination.copy(id = destination.id, name = "updatedName", mail = updatedMail, type = DestinationType.MAIL))
+        assertEquals("Incorrect destination recipients after update", "updated2@localhost.localdomain", updatedDestination.mail?.recipients)
     }
 
     fun `test delete destination`() {

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
     compile "org.apache.httpcomponents:httpcore:4.4.5"
     compile "org.apache.httpcomponents:httpclient:4.5.10"
+    compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.easymock:easymock:4.0.1"

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClient.java
@@ -1,0 +1,94 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.destination.client;
+
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.BaseMessage;
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.MailMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.Strings;
+import java.util.Properties;
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+/**
+ * This class handles the connections to the given Destination.
+ */
+public class DestinationMailClient {
+
+    private static final Logger logger = LogManager.getLogger(DestinationMailClient.class);
+    
+    public String execute(BaseMessage message) throws Exception {
+        if (message instanceof MailMessage) {
+            MailMessage mailMessage = (MailMessage) message;
+            Session session = null;
+
+            Properties prop = new Properties();
+            prop.put("mail.transport.protocol", "smtp");
+            prop.put("mail.smtp.host", mailMessage.getHost());
+            prop.put("mail.smtp.port", mailMessage.getPort());
+
+            prop.put("mail.smtp.auth", mailMessage.getAuthEnable());
+            if ( mailMessage.getAuthEnable() ) {
+                session = Session.getInstance(prop, new javax.mail.Authenticator() {
+	    	        protected PasswordAuthentication getPasswordAuthentication() {
+		    	        return new PasswordAuthentication(mailMessage.getUsername(), mailMessage.getPassword());
+		            }
+	            });
+            } else {
+                session = Session.getInstance(prop);
+            }
+
+            switch(mailMessage.getMethod()) {
+            case "ssl":
+                prop.put("mail.smtp.ssl.enable", true);
+                break;
+            case "starttls":
+                prop.put("mail.smtp.starttls.enable", true);
+                break;
+            }
+
+            try {
+                Message mailmsg = new MimeMessage(session);
+                mailmsg.setFrom(new InternetAddress(mailMessage.getFrom()));
+                mailmsg.setRecipients(Message.RecipientType.TO, InternetAddress.parse(mailMessage.getRecipients()));
+                mailmsg.setSubject(mailMessage.getSubject());
+
+                MimeBodyPart mimeBodyPart = new MimeBodyPart();
+                mimeBodyPart.setContent(message.getMessageContent(), "text/html");
+                Multipart multipart = new MimeMultipart();
+                multipart.addBodyPart(mimeBodyPart);
+
+                mailmsg.setContent(multipart);
+                SendMessage(mailmsg);
+            } catch (MessagingException e) {
+                return e.getMessage();
+            }
+        }
+        return "Sent";
+    }
+
+    /*
+     * This method is useful for Mocking the client
+     */
+    public void SendMessage(Message msg) throws Exception {
+        Transport.send(msg);
+    }
+
+}

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClient.java
@@ -24,9 +24,7 @@ import org.elasticsearch.common.Strings;
 import java.util.Properties;
 import javax.mail.*;
 import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 
 /**
  * This class handles the connections to the given Destination.

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClient.java
@@ -22,9 +22,14 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.Strings;
 import java.util.Properties;
-import javax.mail.*;
+import javax.mail.Authenticator;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
 
 /**
  * This class handles the connections to the given Destination.
@@ -43,18 +48,17 @@ public class DestinationMailClient {
             prop.put("mail.smtp.host", mailMessage.getHost());
             prop.put("mail.smtp.port", mailMessage.getPort());
 
-            if ( mailMessage.getUsername() != null && !mailMessage.getUsername().equals("".toCharArray())) {
+            if (mailMessage.getUsername() != null && !mailMessage.getUsername().equals("".toCharArray())) {
                 prop.put("mail.smtp.auth", true);
-                session = Session.getInstance(prop, new javax.mail.Authenticator() {
-	    	        protected PasswordAuthentication getPasswordAuthentication() {
-                        try (
-                            SecureString username = mailMessage.getUsername().clone();
-                            SecureString password = mailMessage.getPassword().clone())
-                        {
-     		    	        return new PasswordAuthentication(username.toString(), password.toString());
+                try {
+                    session = Session.getInstance(prop, new Authenticator() {
+	                    protected PasswordAuthentication getPasswordAuthentication() {
+                            return new PasswordAuthentication(mailMessage.getUsername().toString(), mailMessage.getPassword().toString());
                         }
-		            }
-	            });
+		            });
+                } catch (IllegalStateException e) {
+                    return e.getMessage();
+                }
             } else {
                 session = Session.getInstance(prop);
             }

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClientPool.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationMailClientPool.java
@@ -13,11 +13,18 @@
  *   permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.alerting.destination.message;
+package com.amazon.opendistroforelasticsearch.alerting.destination.client;
 
 /**
- * Supported notification destinations
+ *  This class provides Client to the relevant destinations
  */
-public enum DestinationType {
-    CHIME, SLACK, CUSTOMWEBHOOK, MAIL
+public final class DestinationMailClientPool {
+
+    private static final DestinationMailClient mailClient = new DestinationMailClient();
+
+    private DestinationMailClientPool() { }
+
+    public static DestinationMailClient getMailClient() {
+        return mailClient;
+    }
 }

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/factory/DestinationFactoryProvider.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/factory/DestinationFactoryProvider.java
@@ -33,6 +33,7 @@ public class DestinationFactoryProvider {
         destinationFactoryMap.put(DestinationType.CHIME, new ChimeDestinationFactory());
         destinationFactoryMap.put(DestinationType.SLACK, new SlackDestinationFactory());
         destinationFactoryMap.put(DestinationType.CUSTOMWEBHOOK, new CustomWebhookDestinationFactory());
+        destinationFactoryMap.put(DestinationType.MAIL, new MailDestinationFactory());
     }
 
     /**

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/factory/MailDestinationFactory.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/factory/MailDestinationFactory.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.destination.factory;
+
+import com.amazon.opendistroforelasticsearch.alerting.destination.client.DestinationMailClient;
+import com.amazon.opendistroforelasticsearch.alerting.destination.client.DestinationMailClientPool;
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.MailMessage;
+import com.amazon.opendistroforelasticsearch.alerting.destination.response.DestinationMailResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This class handles the client responsible for submitting the messages to Mail destination.
+ */
+public class MailDestinationFactory implements DestinationFactory<MailMessage, DestinationMailClient>{
+
+    private DestinationMailClient destinationMailClient;
+
+    private static final Logger logger = LogManager.getLogger(MailDestinationFactory.class);
+
+    public MailDestinationFactory() {
+        this.destinationMailClient = DestinationMailClientPool.getMailClient();
+    }
+
+    @Override
+    public DestinationMailResponse publish(MailMessage message) {
+        try {
+            String response = getClient(message).execute(message);
+            int status = response == "Sent" ? 0 : 1;
+            return new DestinationMailResponse.Builder().withStatusCode(status).withResponseContent(response).build();
+        } catch (Exception ex) {
+            logger.error("Exception publishing Message: " + message.toString(), ex);
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    public DestinationMailClient getClient(MailMessage message) {
+        return destinationMailClient;
+    }
+
+    /*
+     *  This function can be used to mock the client for unit test
+     */
+    public void setClient(DestinationMailClient client) {
+        this.destinationMailClient = client;
+    }
+
+}

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/message/MailMessage.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/message/MailMessage.java
@@ -1,0 +1,205 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.destination.message;
+
+import org.elasticsearch.common.Strings;
+
+import java.util.Map;
+
+/**
+ * This class holds the content of a Mail message
+ */
+public class MailMessage extends BaseMessage {
+
+    private String message;
+    private String host;
+    private int port;
+    private Boolean auth;
+    private String method;
+    private String from;
+    private String recipients;
+    private String subject;
+    private final String userName;
+    private final String password;
+
+    private MailMessage(final DestinationType destinationType,
+                                 final String destinationName,
+                                 final String host,
+                                 final Integer port,
+                                 final Boolean auth,
+                                 final String method,
+                                 final String from,
+                                 final String recipients,
+                                 final String subject,
+                                 final String userName,
+                                 final String password,
+                                 final String message) {
+
+        super(destinationType, destinationName, message);
+
+        if (DestinationType.MAIL != destinationType) {
+            throw new IllegalArgumentException("Channel Type does not match Mail");
+        }
+
+        if (Strings.isNullOrEmpty(message)) {
+            throw new IllegalArgumentException("Message content is missing");
+        }
+
+        if(Strings.isNullOrEmpty(host)) {
+            throw new IllegalArgumentException("Host name should be provided");
+        }
+
+        if(Strings.isNullOrEmpty(from)) {
+            throw new IllegalArgumentException("From address should be provided");
+        }
+
+        if(Strings.isNullOrEmpty(recipients)) {
+            throw new IllegalArgumentException("Comma separated recipients should be provided");
+        }
+
+        this.message = message;
+        this.host = host;
+        this.port = port==null ? 25 : port;
+        this.method = method==null ? "plain" : method;
+        this.auth = auth==null ? false : auth;
+        this.from = from;
+        this.recipients = recipients;
+        this.subject = subject == "" ? destinationName : subject;
+        this.userName = userName;
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "DestinationType: " + destinationType + ", DestinationName:" +  destinationName +
+                ", Host: " + host + ", Port: " + port + ", Message: " + message;
+    }
+
+    public static class Builder {
+        private String message;
+        private DestinationType destinationType;
+        private String destinationName;
+        private String host;
+        private Integer port;
+        private Boolean auth;
+        private String method;
+        private String from;
+        private String recipients;
+        private String subject;
+        private String userName;
+        private String password;
+
+        public Builder(String destinationName) {
+            this.destinationName = destinationName;
+            this.destinationType = DestinationType.MAIL;
+        }
+
+        public MailMessage.Builder withHost(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public MailMessage.Builder withPort(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public MailMessage.Builder withAuth(Boolean auth) {
+            this.auth = auth;
+            return this;
+        }
+
+        public MailMessage.Builder withMethod(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public MailMessage.Builder withFrom(String from) {
+            this.from = from;
+            return this;
+        }
+
+        public MailMessage.Builder withRecipients(String recipients) {
+            this.recipients = recipients;
+            return this;
+        }
+
+        public MailMessage.Builder withSubject(String subject) {
+            this.subject = subject;
+            return this;
+        }
+
+        public MailMessage.Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public MailMessage.Builder withUserName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public MailMessage.Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public MailMessage build() {
+            MailMessage mailMessage = new MailMessage(
+                    this.destinationType, this.destinationName,
+                    this.host, this.port, this.auth, this.method,
+                    this.from, this.recipients, this.subject,
+                    this.userName, this.password, this.message);
+            return mailMessage;
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public Boolean getAuthEnable() {
+        return auth;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+    
+    public String getFrom() {
+        return from;
+    }
+
+    public String getRecipients() {
+        return recipients;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getUsername() {
+        return userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/message/MailMessage.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/message/MailMessage.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.alerting.destination.message;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.SecureString;
 
 import java.util.Map;
 
@@ -32,20 +33,19 @@ public class MailMessage extends BaseMessage {
     private String from;
     private String recipients;
     private String subject;
-    private final String userName;
-    private final String password;
+    private final SecureString username;
+    private final SecureString password;
 
     private MailMessage(final DestinationType destinationType,
                                  final String destinationName,
                                  final String host,
                                  final Integer port,
-                                 final Boolean auth,
                                  final String method,
                                  final String from,
                                  final String recipients,
                                  final String subject,
-                                 final String userName,
-                                 final String password,
+                                 final SecureString username,
+                                 final SecureString password,
                                  final String message) {
 
         super(destinationType, destinationName, message);
@@ -72,13 +72,12 @@ public class MailMessage extends BaseMessage {
 
         this.message = message;
         this.host = host;
-        this.port = port==null ? 25 : port;
-        this.method = method==null ? "plain" : method;
-        this.auth = auth==null ? false : auth;
+        this.port = port == null ? 25 : port;
+        this.method = method == null ? "none" : method;
         this.from = from;
         this.recipients = recipients;
         this.subject = subject == "" ? destinationName : subject;
-        this.userName = userName;
+        this.username = username;
         this.password = password;
     }
 
@@ -99,8 +98,8 @@ public class MailMessage extends BaseMessage {
         private String from;
         private String recipients;
         private String subject;
-        private String userName;
-        private String password;
+        private SecureString username;
+        private SecureString password;
 
         public Builder(String destinationName) {
             this.destinationName = destinationName;
@@ -114,11 +113,6 @@ public class MailMessage extends BaseMessage {
 
         public MailMessage.Builder withPort(Integer port) {
             this.port = port;
-            return this;
-        }
-
-        public MailMessage.Builder withAuth(Boolean auth) {
-            this.auth = auth;
             return this;
         }
 
@@ -147,12 +141,12 @@ public class MailMessage extends BaseMessage {
             return this;
         }
 
-        public MailMessage.Builder withUserName(String userName) {
-            this.userName = userName;
+        public MailMessage.Builder withUserName(SecureString username) {
+            this.username = username;
             return this;
         }
 
-        public MailMessage.Builder withPassword(String password) {
+        public MailMessage.Builder withPassword(SecureString password) {
             this.password = password;
             return this;
         }
@@ -160,9 +154,9 @@ public class MailMessage extends BaseMessage {
         public MailMessage build() {
             MailMessage mailMessage = new MailMessage(
                     this.destinationType, this.destinationName,
-                    this.host, this.port, this.auth, this.method,
+                    this.host, this.port, this.method,
                     this.from, this.recipients, this.subject,
-                    this.userName, this.password, this.message);
+                    this.username, this.password, this.message);
             return mailMessage;
         }
     }
@@ -173,10 +167,6 @@ public class MailMessage extends BaseMessage {
 
     public int getPort() {
         return port;
-    }
-
-    public Boolean getAuthEnable() {
-        return auth;
     }
 
     public String getMethod() {
@@ -195,11 +185,11 @@ public class MailMessage extends BaseMessage {
         return subject;
     }
 
-    public String getUsername() {
-        return userName;
+    public SecureString getUsername() {
+        return username;
     }
 
-    public String getPassword() {
+    public SecureString getPassword() {
         return password;
     }
 }

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/message/MailMessage.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/message/MailMessage.java
@@ -83,7 +83,7 @@ public class MailMessage extends BaseMessage {
 
     @Override
     public String toString() {
-        return "DestinationType: " + destinationType + ", DestinationName:" +  destinationName +
+        return "DestinationType: " + destinationType + ", DestinationName: " +  destinationName +
                 ", Host: " + host + ", Port: " + port + ", Message: " + message;
     }
 

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/response/DestinationMailResponse.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/response/DestinationMailResponse.java
@@ -1,0 +1,57 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.destination.response;
+
+import org.elasticsearch.common.Strings;
+
+/**
+ * This class is a place holder for http response metadata
+ */
+public class DestinationMailResponse extends BaseResponse {
+
+    private String responseContent;
+
+    private DestinationMailResponse(final String responseString, final int statusCode) {
+        super(statusCode);
+        if (Strings.isNullOrEmpty(responseString)) {
+            throw new IllegalArgumentException("Response is missing");
+        }
+        this.responseContent = responseString;
+    }
+
+    public static class Builder {
+        private String responseContent;
+        private Integer statusCode = null;
+
+        public DestinationMailResponse.Builder withResponseContent(String responseContent) {
+            this.responseContent = responseContent;
+            return this;
+        }
+
+        public DestinationMailResponse.Builder withStatusCode(Integer statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public DestinationMailResponse build() {
+            return new DestinationMailResponse(responseContent, statusCode);
+        }
+    }
+
+    public String getResponseContent() {
+        return this.responseContent;
+    }
+}

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/MailDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/MailDestinationTest.java
@@ -1,0 +1,151 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.destination;
+
+import com.amazon.opendistroforelasticsearch.alerting.destination.factory.DestinationFactoryProvider;
+import com.amazon.opendistroforelasticsearch.alerting.destination.factory.MailDestinationFactory;
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.BaseMessage;
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.DestinationType;
+import com.amazon.opendistroforelasticsearch.alerting.destination.message.MailMessage;
+import com.amazon.opendistroforelasticsearch.alerting.destination.client.DestinationMailClient;
+import com.amazon.opendistroforelasticsearch.alerting.destination.response.DestinationMailResponse;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+import javax.mail.Message;
+import javax.mail.Transport;
+import javax.mail.internet.MimeMessage;
+import javax.mail.MessagingException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MailDestinationTest {
+
+    @Test
+    public void testMailMessage() throws Exception {
+
+        DestinationMailResponse expectedMailResponse = new DestinationMailResponse.Builder().withResponseContent("Sent")
+                .withStatusCode(0).build();
+
+        DestinationMailClient mailClient = EasyMock.partialMockBuilder(DestinationMailClient.class).addMockedMethod("SendMessage").createMock();
+        mailClient.SendMessage(EasyMock.anyObject(Message.class));
+
+        MailDestinationFactory mailDestinationFactory = new MailDestinationFactory();
+        mailDestinationFactory.setClient(mailClient);
+
+        DestinationFactoryProvider.setFactory(DestinationType.MAIL, mailDestinationFactory);
+
+        String message = "{\"text\":\"Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present\"}";
+        BaseMessage bm = new MailMessage.Builder("abc")
+                .withMessage(message)
+                .withHost("abc.com")
+                .withFrom("test@abc.com")
+                .withRecipients("test@abc.com").build();
+
+        DestinationMailResponse actualMailResponse = (DestinationMailResponse) Notification.publish(bm);
+        assertEquals(expectedMailResponse.getResponseContent(), actualMailResponse.getResponseContent());
+        assertEquals(expectedMailResponse.getStatusCode(), actualMailResponse.getStatusCode());
+    }
+
+    @Test
+    public void testFailingMailMessage() throws Exception {
+
+        DestinationMailResponse expectedMailResponse = new DestinationMailResponse.Builder().withResponseContent("Couldn't connect to host, port: localhost, 55555; timeout -1")
+                .withStatusCode(1).build();
+
+        DestinationMailClient mailClient = EasyMock.partialMockBuilder(DestinationMailClient.class).addMockedMethod("SendMessage").createMock();
+        mailClient.SendMessage(EasyMock.anyObject(Message.class));
+        EasyMock.expectLastCall().andThrow(new MessagingException("Couldn't connect to host, port: localhost, 55555; timeout -1"));
+        EasyMock.replay(mailClient);
+
+        MailDestinationFactory mailDestinationFactory = new MailDestinationFactory();
+        mailDestinationFactory.setClient(mailClient);
+
+        DestinationFactoryProvider.setFactory(DestinationType.MAIL, mailDestinationFactory);
+
+        String message = "{\"text\":\"Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present\"}";
+        BaseMessage bm = new MailMessage.Builder("abc")
+                .withMessage(message)
+                .withHost("localhost")
+                .withPort(55555)
+                .withFrom("test@abc.com")
+                .withRecipients("test@abc.com").build();
+
+        DestinationMailResponse actualMailResponse = (DestinationMailResponse) Notification.publish(bm);
+        EasyMock.verify(mailClient);
+        assertEquals(expectedMailResponse.getResponseContent(), actualMailResponse.getResponseContent());
+        assertEquals(expectedMailResponse.getStatusCode(), actualMailResponse.getStatusCode());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHostMissingMessage() {
+        try {
+            MailMessage message = new MailMessage.Builder("mail")
+                    .withMessage("dummyMessage")
+                    .withFrom("test@abc.com")
+                    .withRecipients("test@abc.com").build();
+                    
+        } catch (Exception ex) {
+            Assert.assertEquals("Host name should be provided", ex.getMessage());
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testContentMissingMessage() {
+        try {
+            MailMessage message = new MailMessage.Builder("mail")
+                    .withHost("abc.com")
+                    .withFrom("test@abc.com")
+                    .withRecipients("test@abc.com").build();
+        } catch (Exception ex) {
+            assertEquals("Message content is missing", ex.getMessage());
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromMissingMessage() {
+        try {
+            MailMessage message = new MailMessage.Builder("mail")
+                    .withMessage("dummyMessage")
+                    .withHost("abc.com")
+                    .withRecipients("test@abc.com").build();
+                    
+        } catch (Exception ex) {
+            Assert.assertEquals("From address should be provided", ex.getMessage());
+            throw ex;
+        }
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testRecipientsMissingMessage() {
+        try {
+            MailMessage message = new MailMessage.Builder("mail")
+                    .withMessage("dummyMessage")
+                    .withHost("abc.com")
+                    .withFrom("test@abc.com").build();
+                    
+        } catch (Exception ex) {
+            Assert.assertEquals("Comma separated recipients should be provided", ex.getMessage());
+            throw ex;
+        }
+    }
+}

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/MailDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/MailDestinationTest.java
@@ -101,7 +101,7 @@ public class MailDestinationTest {
                     .withMessage("dummyMessage")
                     .withFrom("test@abc.com")
                     .withRecipients("test@abc.com").build();
-                    
+
         } catch (Exception ex) {
             Assert.assertEquals("Host name should be provided", ex.getMessage());
             throw ex;
@@ -128,13 +128,13 @@ public class MailDestinationTest {
                     .withMessage("dummyMessage")
                     .withHost("abc.com")
                     .withRecipients("test@abc.com").build();
-                    
+
         } catch (Exception ex) {
             Assert.assertEquals("From address should be provided", ex.getMessage());
             throw ex;
         }
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testRecipientsMissingMessage() {
         try {
@@ -142,7 +142,7 @@ public class MailDestinationTest {
                     .withMessage("dummyMessage")
                     .withHost("abc.com")
                     .withFrom("test@abc.com").build();
-                    
+
         } catch (Exception ex) {
             Assert.assertEquals("Comma separated recipients should be provided", ex.getMessage());
             throw ex;


### PR DESCRIPTION
*Description of changes:*
Issue #3 : Add an Email destination

 * Support SMTP SSL/TLS and authentification
 * Message's body is plain text for this first implementation
 * Mail server's parameters are stored in elasticsearch.yml and elasticsearch keystore
 
How to configure it : 
1. Add these settings to elasticsearch.yml : 
```yaml
opendistro.alerting.destination.mail.host: "localhost"
opendistro.alerting.destination.mail.port: 25
# Connexion method : "none", "ssl" or "starttls"
opendistro.alerting.destination.mail.method: "none"
opendistro.alerting.destination.mail.from: "test@localhost"
```
2. If authentification needed, add these settings to elasticsearch keystore : 
```bash
elasticsearch-keystore add opendistro.alerting.destination.mail.username
elasticsearch-keystore add opendistro.alerting.destination.mail.password
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
