### PR TITLE
Adds maven publish task to notification (#97)

### DIFF
--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -13,8 +13,11 @@
  *   permissions and limitations under the License.
  */
 
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
 apply plugin: 'jacoco'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
@@ -23,4 +26,79 @@ dependencies {
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.easymock:easymock:4.0.1"
+}
+
+shadowJar {
+    relocate 'org.apache.http', 'com.amazon.opendistroforelasticsearch.notification.repackage.org.apache.http'
+    relocate 'org.apache.commons.logging', 'com.amazon.opendistroforelasticsearch.notification.repackage.org.apache.commons.logging'
+    relocate 'org.apache.commons.codec', 'com.amazon.opendistroforelasticsearch.notification.repackage.org.apache.commons.codec'
+    classifier = null
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allJava
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+publishing {
+    publications {
+        shadow(MavenPublication) {
+            project.shadow.component(it)
+            groupId = 'com.amazon.opendistroforelasticsearch'
+            artifactId = 'notification'
+
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "Open Distro for Elasticsearch Notification"
+                packaging = "jar"
+                url = "https://github.com/opendistro-for-elasticsearch/alerting"
+                description = "Open Distro for Elasticsearch Notification"
+                scm {
+                    connection = "scm:git@github.com:opendistro-for-elasticsearch/alerting.git"
+                    developerConnection = "scm:git@github.com:opendistro-for-elasticsearch/alerting.git"
+                    url = "git@github.com:opendistro-for-elasticsearch/alerting.git"
+                }
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "amazonwebservices"
+                        organization = "Amazon Web Services"
+                        organizationUrl = "https://aws.amazon.com"
+                    }
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "sonatype-staging"
+            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            credentials {
+                username project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : ''
+                password project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : ''
+            }
+        }
+    }
+
+    // TODO - enabled debug logging for the time being, remove this eventually
+    gradle.startParameter.setShowStacktrace(ShowStacktrace.ALWAYS)
+    gradle.startParameter.setLogLevel(LogLevel.DEBUG)
+
+    signing {
+        required { gradle.taskGraph.hasTask("publishShadowPublicationToSonatype-stagingRepository") }
+        sign publishing.publications.shadow
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backporting maven publish task to earlier versions as ISM needs notifications published to maven


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
