### PR TITLE
Allows encoding while constructing HTTP request while sending notific…

### DIFF
--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
@@ -38,6 +38,7 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 
@@ -108,7 +109,7 @@ public class DestinationHttpClient {
         }
 
         httpPostRequest.setURI(uri);
-        StringEntity entity = new StringEntity(extractBody(message));
+        StringEntity entity = new StringEntity(extractBody(message), StandardCharsets.UTF_8);
         httpPostRequest.setEntity(entity);
 
         return HTTP_CLIENT.execute(httpPostRequest);


### PR DESCRIPTION
*Issue #, if available:*
#33 
*Description of changes:*

We were not encoding the message while publishing, using the [StringEntity](https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/entity/StringEntity.html#StringEntity(java.lang.String,%20org.apache.http.entity.ContentType)) constructor with the mime-type and charset.

* Chime / Slack Defaults `application/json`
* Custom Webhook , Default to `application/json` , user can choose other values.

Sample Chime notification : 
![Screen Shot 2019-04-24 at 9 45 55 AM](https://user-images.githubusercontent.com/578861/56677659-d6a73580-6675-11e9-9f71-4e45f882f625.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
