### PR TITLE
Push Notification Jar to Maven

### DIFF
--- a/.github/workflows/push-notification-jar.yml
+++ b/.github/workflows/push-notification-jar.yml
@@ -1,0 +1,47 @@
+name: Upload Notification Jar to Maven
+
+on:
+  push:
+    tags: 
+      - v*
+jobs:
+  upload-notification-jar:
+    runs-on: [ubuntu-16.04]
+    strategy:
+      matrix:
+        java: [12]
+    name: Upload Notification Jar to Maven
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v1
+        
+      - name: Configure AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Upload Notification Jar to Maven
+        env:
+          passphrase: ${{ secrets.PASSPHRASE }}
+        run: |
+          cd ..
+          export JAVA12_HOME=$JAVA_HOME
+          aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
+          aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
+          
+          gpg --import pgp-public-key
+          gpg --allow-secret-key-import --import pgp-private-key
+
+          mkdir /home/runner/.gradle
+          aws s3 cp s3://opendistro-docs/github-actions/gradle.properties /home/runner/.gradle/
+          
+          cd alerting/notification
+          
+          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=12 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/12.0.2/x64/lib/security/cacerts

--- a/.github/workflows/push-notification-jar.yml
+++ b/.github/workflows/push-notification-jar.yml
@@ -13,7 +13,7 @@ jobs:
     name: Upload Notification Jar to Maven
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         
       - name: Configure AWS CLI
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/push-notification-jar.yml
+++ b/.github/workflows/push-notification-jar.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   upload-notification-jar:
     runs-on: [ubuntu-16.04]
-    strategy:
-      matrix:
-        java: [12]
     name: Upload Notification Jar to Maven
     steps:
       - name: Checkout Repo
@@ -25,7 +22,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: '12'
 
       - name: Upload Notification Jar to Maven
         env:


### PR DESCRIPTION
As of now the ISM plugin team has to depend on infra team to push the notification and job-scheduler jars to maven before they start the build process for new release.
This job will push the notification jar to staging repository in maven from where the user can publish the jar into prod. The job will be triggered whenever a new tag is cut for the new release.