### PR TITLE
CI/CD GitHub actions

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         java: [12]
 
-    name: Build and Test Alerting Plugin
+    name: Build and Release Alerting Plugin
     runs-on: [ubuntu-16.04]
 
     steps:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,43 @@
+name: Release Alerting Artefacts
+on:
+  push:
+    branches:
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Test Alerting Plugin
+    runs-on: [ubuntu-16.04]
+
+    steps:
+      - name: Checkout Alerting
+        uses: actions/checkout@v1
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          #!/bin/bash
+          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+          artifact=`ls alerting/build/distributions/*.zip`
+          rpm_artifact=`ls alerting/build/distributions/*.rpm`
+          deb_artifact=`ls alerting/build/distributions/*.deb`
+          
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-alerting/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-alerting/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-alerting/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       
       - name: Run build
         run: |
-          ./gradlew build
+          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
       
       - name: Pull and Run Docker
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,59 @@
+name: Build and Test Alerting
+on:
+  push:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Test Alerting Plugin
+    runs-on: [ubuntu-16.04]
+
+    steps:
+      - name: Checkout Alerting
+        uses: actions/checkout@v1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+      
+      - name: Pull and Run Docker
+        run: |
+          plugin=`ls alerting/build/distributions/*.zip`
+          version=`echo $plugin|awk -F- '{print $2}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $2}'| cut -d. -f 1-4`
+          echo $version
+          cd ..
+          
+          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
+          then
+            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_alerting ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_alerting; fi" >> Dockerfile
+            echo "ADD alerting/alerting/build/distributions/opendistro_alerting-$plugin_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro_alerting-$plugin_version.zip" >> Dockerfile
+            
+            docker build -t odfe-alerting:test .
+          fi
+          
+      - name: Run Docker Image
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-alerting:test
+          sleep 15
+          curl -XGET http://localhost:9200/_cat/plugins
+          
+      - name: Run Alerting Test
+        run: |
+          cd alerting
+          ../gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       
       - name: Run build
         run: |
-          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+          ./gradlew build
       
       - name: Pull and Run Docker
         run: |


### PR DESCRIPTION
###CI.yml

This job will trigger on every code checkin in master and opendistro branches which then will build the alerting plugin and run integration tests against the respective version of opendistro staging docker image. 
Before running the test the job will first remove alerting plugin, if available, then it will re-install the built plugin.

###CD.yml
This job will trigger whenever a code checkin is made on an opendistro branch or a new opendistro branch is cut. It will build all the artifacts and then upload to respective S3 paths. 

Assumption: the new opendistro branch is cut only when the plugin is ready to be released.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
