### PR TITLE
Adds support for Elasticsearch 7.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,25 @@ However, to build the `alerting` plugin subproject, we also use the Elastic buil
 
 1. `./gradlew build` builds and tests all subprojects.
 2. `./gradlew :alerting:run` launches a single node cluster with the alerting plugin installed.
-3. `./gradlew :alerting:integTest` launches a single node cluster with the alerting plugin installed and runs all integ tests.
-4. ` ./gradlew :alerting:integTest --tests="**.test execute foo"` runs a single integ test class or method
+3. `./gradlew :alerting:run -PnumNodes=3` launches a multi-node cluster with the alerting plugin installed.
+4. `./gradlew :alerting:integTest` launches a single node cluster with the alerting plugin installed and runs all integ tests.
+5. `./gradlew :alerting:integTest -PnumNodes=3` launches a multi-node cluster with the alerting plugin installed and runs all integ tests.
+6. `./gradlew :alerting:integTest -Dtests.class="*MonitorRunnerIT"` runs a single integ test class
+7. ` ./gradlew :alerting:integTest -Dtests.method="test execute monitor with dryrun"` runs a single integ test method
  (remember to quote the test method name if it contains spaces).
 
-When launching a cluster using one of the above commands, logs are placed in `alerting/build/cluster/run node0/elasticsearch-<version>/logs`. Though the logs are teed to the console, in practices it's best to check the actual log file.
+When launching a cluster using one of the above commands, logs are placed in `alerting/build/testclusters/integTest-0/logs/`. Though the logs are teed to the console, in practices it's best to check the actual log file.
 
 
 ### Debugging
 
-Sometimes it's useful to attach a debugger to either the Elasticsearch cluster or the integ tests to see what's going on. When running unit tests, hit **Debug** from the IDE's gutter to debug the tests.  To debug code running in an actual server, run:
+Sometimes it's useful to attach a debugger to either the Elasticsearch cluster or the integ tests to see what's going on. When running unit tests, hit **Debug** from the IDE's gutter to debug the tests.
+You must start your debugger to listen for remote JVM before running the below commands.
+
+To debug code running in an actual server, run:
 
 ```
-./gradlew :alerting:integTest --debug-jvm # to start a cluster and run integ tests
+./gradlew :alerting:integTest -Des.debug # to start a cluster and run integ tests
 ```
 
 OR
@@ -63,7 +69,9 @@ OR
 ./gradlew :alerting:run --debug-jvm # to just start a cluster that can be debugged
 ```
 
-The Elasticsearch server JVM will launch suspended and wait for a debugger to attach to `localhost:8000` before starting the Elasticsearch server.
+The Elasticsearch server JVM will launch suspended and wait for a debugger to attach to `localhost:5005` before starting the Elasticsearch server.
+The IDE needs to listen for the remote JVM. If using Intellij you must set your debug configuration to "Listen to remote JVM" and make sure "Auto Restart" is checked.
+You must start your debugger to listen for remote JVM before running the commands.
 
 To debug code running in an integ test (which exercises the server from a separate JVM), run:
 
@@ -76,32 +84,14 @@ The test runner JVM will start suspended and wait for a debugger to attach to `l
 
 ### Advanced: Launching multi-node clusters locally
 
-Sometimes you need to launch a cluster with more than one Elasticsearch server process. The `startMultiNodeXX` tasks can help. There are two ways to use them:
+Sometimes you need to launch a cluster with more than one Elasticsearch server process.
 
+You can do this by running `./gradlew :alerting:run -PnumNodes=<numberOfNodesYouWant>`
 
-#### Option 1: Start and stop all nodes together
+You can also run the integration tests against a multi-node cluster by running `./gradlew :alerting:integTest -PnumNodes=<numberOfNodesYouWant>`
 
-If you need a multi-node cluster where all nodes are started together, use: 
-
-```
-./gradlew -PnumNodes=2 startMultiNode ... # to launch 2 nodes
-
-```
-
-Remember to manually kill the nodes when you're done.
-
-
-#### Option 2: Nodes join and leave the cluster independently
-
-If you need a multi-node cluster where you'd like to be able to add and kill each node independently, use:
-
-```
-./gradlew startMultiNode1 
-./gradlew startMultiNode2
-... and so on
-```
-
-Just like option 1, remember to manually kill the nodes when you're done.
+You can also debug a multi-node cluster, by using a combination of above multi-node and debug steps.
+But, you must set up debugger configurations to listen on each port starting from `5005` and increasing by 1 for each node.  
 
 
 ## Code of Conduct

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -1,3 +1,6 @@
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 /*
  *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -16,10 +19,16 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'elasticsearch.esplugin'
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'jacoco'
-if (!System.properties.containsKey('tests.rest.cluster') && !System.properties.containsKey('tests.cluster')) {
+
+def usingRemoteCluster = System.properties.containsKey('tests.rest.cluster') || System.properties.containsKey('tests.cluster')
+def usingMultiNode = project.properties.containsKey('numNodes')
+// Only apply jacoco test coverage if we are running a local single node cluster
+if (!usingRemoteCluster && !usingMultiNode) {
     apply from: '../build-tools/esplugin-coverage.gradle'
 }
+
 ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
@@ -76,30 +85,6 @@ licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 
-// See package README.md for details on using these tasks.
-(1..3).each { i ->
-    def _numNodes = findProperty('numNodes') as Integer ?: 1
-    tasks.create(name : "runMultiNode$i", type: org.elasticsearch.gradle.test.RunTask) {
-        daemonize = true
-        numNodes = _numNodes
-        setting 'node.name', "multi-node-$i"
-        setting 'http.port', '9200-9300'
-        setting 'transport.tcp.port', '9300-9400'
-        clusterName = 'multi-node-run'
-        plugin project.path
-        distribution = "oss-zip"
-    }
-    
-    tasks.create(name: "startMultiNode$i") {
-        if (_numNodes == 1) {
-            dependsOn "runMultiNode${i}#start"
-        } else {
-            (0..<_numNodes).each { n -> dependsOn "runMultiNode${i}#node${n}.start" }
-        }
-    }
-}
-task startMultiNode(dependsOn: startMultiNode1)
-
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
 es_tmp_dir.mkdirs()
 
@@ -107,24 +92,57 @@ test {
     systemProperty 'tests.security.manager', 'false'
 }
 
-integTestRunner {
-    systemProperty 'tests.security.manager', 'false'
-    systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
-    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
-    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
-    doFirst { systemProperty 'cluster.debug', integTestCluster.debug }
+def _numNodes = findProperty('numNodes') as Integer ?: 1
+integTest {
+    runner {
+        systemProperty 'tests.security.manager', 'false'
+        systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
+        // The 'doFirst' delays till execution time.
+        doFirst {
+            // Tell the test JVM if the cluster JVM is running under a debugger so that tests can
+            // use longer timeouts for requests.
+            def isDebuggingCluster = getDebug() || System.getProperty("test.debug") != null
+            systemProperty 'cluster.debug', isDebuggingCluster
+            // Set number of nodes system property to be used in tests
+            systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+            // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
+            // not being written, the waitForAllConditions ensures it's written
+            getClusters().forEach { cluster ->
+                cluster.waitForAllConditions()
+            }
+        }
 
-    // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
-    if (System.getProperty("test.debug") != null) {
-        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+        // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
+        if (System.getProperty("test.debug") != null) {
+            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+        }
     }
 }
 
-integTestCluster {
-    distribution = "oss-zip"
+testClusters.integTest {
+    testDistribution = "OSS"
+    // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
+    if (_numNodes > 1) numberOfNodes = _numNodes
+    // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore
+    // i.e. we have to use a custom property to flag when we want to debug elasticsearch JVM
+    // since we also support multi node integration tests we increase debugPort per node
+    if (System.getProperty("es.debug") != null) {
+        def debugPort = 5005
+        nodes.forEach { node ->
+            node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=*:${debugPort}")
+            debugPort += 1
+        }
+    }
 }
+
 run {
-    distribution = "oss-zip"
+    doFirst {
+        // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
+        // not being written, the waitForAllConditions ensures it's written
+        getClusters().forEach { cluster ->
+            cluster.waitForAllConditions()
+        }
+    }
 }
 
 apply from: '../build-tools/pkgbuild.gradle'

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
@@ -92,7 +92,7 @@ class IndexUtils {
 
         @JvmStatic
         fun getIndexNameWithAlias(clusterState: ClusterState, alias: String): String {
-            return clusterState.metaData.indices.first { it -> it.value.aliases.containsKey(alias) }.key
+            return clusterState.metaData.indices.first { it.value.aliases.containsKey(alias) }.key
         }
 
         @JvmStatic
@@ -100,8 +100,8 @@ class IndexUtils {
             var oldVersion = NO_SCHEMA_VERSION
             val newVersion = getSchemaVersion(mapping)
 
-            val indexMapping = index.mapping().sourceAsMap()
-            if (indexMapping.containsKey(_META) && indexMapping[_META] is HashMap<*, *>) {
+            val indexMapping = index.mapping()?.sourceAsMap()
+            if (indexMapping != null && indexMapping.containsKey(_META) && indexMapping[_META] is HashMap<*, *>) {
                 val metaData = indexMapping[_META] as HashMap<*, *>
                 if (metaData.containsKey(SCHEMA_VERSION)) {
                     oldVersion = metaData[SCHEMA_VERSION] as Int
@@ -121,7 +121,7 @@ class IndexUtils {
         ) {
             if (clusterState.metaData.indices.containsKey(index)) {
                 if (shouldUpdateIndex(clusterState.metaData.indices[index], mapping)) {
-                    var putMappingRequest: PutMappingRequest = PutMappingRequest(index).type(type).source(mapping, XContentType.JSON)
+                    val putMappingRequest: PutMappingRequest = PutMappingRequest(index).type(type).source(mapping, XContentType.JSON)
                     client.putMapping(putMappingRequest, actionListener)
                 } else {
                     actionListener.onResponse(AcknowledgedResponse(true))

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -48,15 +48,23 @@ import org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.search.SearchModule
 import org.elasticsearch.test.rest.ESRestTestCase
+import org.junit.AfterClass
 import org.junit.rules.DisableOnDebug
 import java.net.URLEncoder
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Instant
 import java.util.Locale
+import javax.management.MBeanServerInvocationHandler
+import javax.management.ObjectName
+import javax.management.remote.JMXConnectorFactory
+import javax.management.remote.JMXServiceURL
 
 abstract class AlertingRestTestCase : ESRestTestCase() {
 
     private val isDebuggingTest = DisableOnDebug(null).isDebugging
     private val isDebuggingRemoteCluster = System.getProperty("cluster.debug", "false")!!.toBoolean()
+    val numberOfNodes = System.getProperty("cluster.number_of_nodes", "1")!!.toInt()
 
     override fun xContentRegistry(): NamedXContentRegistry {
         return NamedXContentRegistry(mutableListOf(Monitor.XCONTENT_REGISTRY,
@@ -363,5 +371,45 @@ abstract class AlertingRestTestCase : ESRestTestCase() {
                         .startObject().field(ScheduledJobSettings.SWEEPER_ENABLED.key, false).endObject()
                         .endObject().string(), ContentType.APPLICATION_JSON))
         return updateResponse
+    }
+
+    companion object {
+        internal interface IProxy {
+            val version: String?
+            var sessionId: String?
+
+            fun getExecutionData(reset: Boolean): ByteArray?
+            fun dump(reset: Boolean)
+            fun reset()
+        }
+
+        /*
+        * We need to be able to dump the jacoco coverage before the cluster shuts down.
+        * The new internal testing framework removed some gradle tasks we were listening to,
+        * to choose a good time to do it. This will dump the executionData to file after each test.
+        * TODO: This is also currently just overwriting integTest.exec with the updated execData without
+        *   resetting after writing each time. This can be improved to either write an exec file per test
+        *   or by letting jacoco append to the file.
+        * */
+        @JvmStatic
+        @AfterClass
+        fun dumpCoverage() {
+            // jacoco.dir set in esplugin-coverage.gradle, if it doesn't exist we don't
+            // want to collect coverage, so we can return early
+            val jacocoBuildPath = System.getProperty("jacoco.dir") ?: return
+            val serverUrl = "service:jmx:rmi:///jndi/rmi://127.0.0.1:7777/jmxrmi"
+            JMXConnectorFactory.connect(JMXServiceURL(serverUrl)).use { connector ->
+                val proxy = MBeanServerInvocationHandler.newProxyInstance(
+                        connector.mBeanServerConnection,
+                        ObjectName("org.jacoco:type=Runtime"),
+                        IProxy::class.java,
+                        false
+                )
+                proxy.getExecutionData(false)?.let {
+                    val path = Path.of("$jacocoBuildPath/integTest.exec")
+                    Files.write(path, it)
+                }
+            }
+        }
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
@@ -174,12 +174,12 @@ class AlertIndicesIT : AlertingRestTestCase() {
     }
 
     private fun assertIndexExists(index: String) {
-        val response = client().makeRequest("HEAD", "$index")
+        val response = client().makeRequest("HEAD", index)
         assertEquals("Index $index does not exist.", RestStatus.OK, response.restStatus())
     }
 
     private fun assertIndexDoesNotExist(index: String) {
-        val response = client().makeRequest("HEAD", "$index")
+        val response = client().makeRequest("HEAD", index)
         assertEquals("Index $index does not exist.", RestStatus.NOT_FOUND, response.restStatus())
     }
 
@@ -210,6 +210,6 @@ class AlertIndicesIT : AlertingRestTestCase() {
         val response = client().makeRequest("POST", "${AlertIndices.HISTORY_ALL}/_search", emptyMap(),
                 StringEntity(request, APPLICATION_JSON))
         assertEquals("Request to get history failed", RestStatus.OK, response.restStatus())
-        return SearchResponse.fromXContent(createParser(jsonXContent, response.entity.content)).hits.totalHits.value
+        return SearchResponse.fromXContent(createParser(jsonXContent, response.entity.content)).hits.totalHits!!.value
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -483,9 +483,9 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals("Scheduled job is not enabled", false, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
         assertEquals("Scheduled job index exists but there are no scheduled jobs.", false, responseMap["scheduled_job_index_exists"])
         val _nodes = responseMap["_nodes"] as Map<String, Int>
-        assertEquals("Incorrect number of nodes", 1, _nodes["total"])
+        assertEquals("Incorrect number of nodes", numberOfNodes, _nodes["total"])
         assertEquals("Failed nodes found during monitor stats call", 0, _nodes["failed"])
-        assertEquals("More than one successful node", 1, _nodes["successful"])
+        assertEquals("More than $numberOfNodes successful node", numberOfNodes, _nodes["successful"])
     }
 
     fun `test monitor stats no jobs`() {
@@ -497,9 +497,9 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals("Scheduled job is not enabled", true, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
         assertEquals("Scheduled job index exists but there are no scheduled jobs.", false, responseMap["scheduled_job_index_exists"])
         val _nodes = responseMap["_nodes"] as Map<String, Int>
-        assertEquals("Incorrect number of nodes", 1, _nodes["total"])
+        assertEquals("Incorrect number of nodes", numberOfNodes, _nodes["total"])
         assertEquals("Failed nodes found during monitor stats call", 0, _nodes["failed"])
-        assertEquals("More than one successful node", 1, _nodes["successful"])
+        assertEquals("More than $numberOfNodes successful node", numberOfNodes, _nodes["successful"])
     }
 
     fun `test monitor stats jobs`() {
@@ -512,12 +512,12 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals("Scheduled job is not enabled", true, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
         assertEquals("Scheduled job index does not exist", true, responseMap["scheduled_job_index_exists"])
         assertEquals("Scheduled job index is not yellow", "yellow", responseMap["scheduled_job_index_status"])
-        assertEquals("Node is not on schedule", 1, responseMap["nodes_on_schedule"])
+        assertEquals("Nodes are not on schedule", numberOfNodes, responseMap["nodes_on_schedule"])
 
         val _nodes = responseMap["_nodes"] as Map<String, Int>
-        assertEquals("Incorrect number of nodes", 1, _nodes["total"])
+        assertEquals("Incorrect number of nodes", numberOfNodes, _nodes["total"])
         assertEquals("Failed nodes found during monitor stats call", 0, _nodes["failed"])
-        assertEquals("More than one successful node", 1, _nodes["successful"])
+        assertEquals("More than $numberOfNodes successful node", numberOfNodes, _nodes["successful"])
     }
 
     @Throws(Exception::class)
@@ -543,12 +543,12 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals("Scheduled job is not enabled", true, responseMap[ScheduledJobSettings.SWEEPER_ENABLED.key])
         assertEquals("Scheduled job index does not exist", true, responseMap["scheduled_job_index_exists"])
         assertEquals("Scheduled job index is not yellow", "yellow", responseMap["scheduled_job_index_status"])
-        assertEquals("Node is not on schedule", 1, responseMap["nodes_on_schedule"])
+        assertEquals("Nodes not on schedule", numberOfNodes, responseMap["nodes_on_schedule"])
 
         val _nodes = responseMap["_nodes"] as Map<String, Int>
-        assertEquals("Incorrect number of nodes", 1, _nodes["total"])
+        assertEquals("Incorrect number of nodes", numberOfNodes, _nodes["total"])
         assertEquals("Failed nodes found during monitor stats call", 0, _nodes["failed"])
-        assertEquals("More than one successful node", 1, _nodes["successful"])
+        assertEquals("More than $numberOfNodes successful node", numberOfNodes, _nodes["successful"])
     }
 
     fun `test monitor stats incorrect metric`() {

--- a/build-tools/esplugin-coverage.gradle
+++ b/build-tools/esplugin-coverage.gradle
@@ -13,9 +13,6 @@
  *   permissions and limitations under the License.
  */
 
-import javax.management.remote.JMXConnectorFactory
-import javax.management.remote.JMXServiceURL
-
 /**
  * ES Plugin build tools don't work with the Gradle Jacoco Plugin to report coverage out of the box. 
  * https://github.com/elastic/elasticsearch/issues/28867.
@@ -33,11 +30,12 @@ apply plugin: 'jacoco'
 
 // Get gradle to generate the required jvm agent arg for us using a dummy tasks of type Test. Unfortunately Elastic's
 // testing tasks don't derive from Test so the jacoco plugin can't do this automatically.
+def jacocoDir = "${buildDir}/jacoco"
 task dummyTest(type: Test) {
     enabled = false
     workingDir = file("/") // Force absolute path to jacoco agent jar
     jacoco {
-        destinationFile = file("${buildDir}/jacoco/test.exec")
+        destinationFile = file("${jacocoDir}/test.exec")
         destinationFile.parentFile.mkdirs()
         jmx = true
     }
@@ -47,14 +45,18 @@ task dummyIntegTest(type: Test) {
     enabled = false
     workingDir = file("/") // Force absolute path to jacoco agent jar
     jacoco {
-        destinationFile = file("${buildDir}/jacoco/integTest.exec")
+        destinationFile = file("${jacocoDir}/integTest.exec")
         destinationFile.parentFile.mkdirs()
         jmx = true
     }
 }
 
-integTestCluster {
-    jvmArgs += " ${dummyIntegTest.jacoco.getAsJvmArg()}"
+integTest.runner {
+    systemProperty 'jacoco.dir', "${jacocoDir}"
+}
+
+testClusters.integTest {
+    jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}"
     systemProperty 'com.sun.management.jmxremote', "true"
     systemProperty 'com.sun.management.jmxremote.authenticate', "false"
     systemProperty 'com.sun.management.jmxremote.port', "7777"
@@ -65,30 +67,14 @@ integTestCluster {
 jacocoTestReport {
     dependsOn integTest, test
     executionData dummyTest.jacoco.destinationFile, dummyIntegTest.jacoco.destinationFile
-    sourceDirectories = sourceSets.main.allSource
-    classDirectories = sourceSets.main.output
+    getSourceDirectories().from(sourceSets.main.allSource)
+    getClassDirectories().from(sourceSets.main.output)
     reports {
         html.enabled = true // human readable
         xml.enabled = true // for coverlay
     }
 }
 
-// See https://www.eclemma.org/jacoco/trunk/doc/api/org/jacoco/agent/rt/IAgent.html
-task dumpCoverage {
-    doFirst {
-        def serverUrl = "service:jmx:rmi:///jndi/rmi://127.0.0.1:7777/jmxrmi"
-        def connector = JMXConnectorFactory.connect(new JMXServiceURL(serverUrl))
-        try {
-            def jacocoMBean = new GroovyMBean(connector.MBeanServerConnection, "org.jacoco:type=Runtime")
-            byte[] data = jacocoMBean.getExecutionData(false)
-            file(dummyIntegTest.jacoco.destinationFile).setBytes(data)
-        } finally {
-            connector.close()
-        }
-    }
-}
 project.gradle.projectsEvaluated {
-    dumpCoverage.dependsOn integTestRunner
-    tasks['integTestCluster#stop'].dependsOn dumpCoverage
-    jacocoTestReport.dependsOn dumpCoverage
+    jacocoTestReport.dependsOn integTest.runner
 }

--- a/build-tools/merged-coverage.gradle
+++ b/build-tools/merged-coverage.gradle
@@ -15,11 +15,7 @@
 
 allprojects {
     plugins.withId('jacoco') {
-        // 0.8.2 doesn't show missing coverage of Kotlin generated methods. Remove once this becomes gradle's default
         jacoco.toolVersion = '0.8.5'
-        tasks.withType(Test) { 
-            jacoco { append = false }
-        }
         // For some reason this dependency isn't getting setup automatically by the jacoco plugin
         tasks.withType(JacocoReport) { 
             dependsOn tasks.withType(Test)
@@ -50,8 +46,8 @@ task jacocoReport(type: JacocoReport, group: 'verification') {
     }
 
     gradle.projectsEvaluated {
-        sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-        classDirectories = files(subprojects.sourceSets.main.output)
+        getSourceDirectories().from(files(subprojects.sourceSets.main.allSource.srcDirs))
+        getClassDirectories().from(files(subprojects.sourceSets.main.output))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        es_version = '7.4.2'
+        es_version = '7.5.2'
         kotlin_version = '1.3.21'
     }
 
@@ -34,6 +34,7 @@ buildscript {
 
 plugins {
     id 'nebula.ospackage' version "5.3.0" apply false
+    id "com.dorongold.task-tree" version "1.5"
 }
 
 apply plugin: 'base'
@@ -41,7 +42,7 @@ apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
-    opendistroVersion = '1.4.0'
+    opendistroVersion = '1.5.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/action/node/ScheduledJobStats.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/action/node/ScheduledJobStats.kt
@@ -46,8 +46,8 @@ class ScheduledJobStats : BaseNodeResponse, ToXContentFragment {
 
     constructor(si: StreamInput): super(si) {
         this.status = si.readEnum(ScheduleStatus::class.java)
-        this.jobSweeperMetrics = JobSweeperMetrics(si)
-        this.jobInfos = si.readList { JobSchedulerMetrics(it) }.toTypedArray()
+        this.jobSweeperMetrics = si.readOptionalWriteable { JobSweeperMetrics(it) }
+        this.jobInfos = si.readOptionalArray({ sti: StreamInput -> JobSchedulerMetrics(sti) }, { size -> arrayOfNulls(size) })
     }
 
     constructor(

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'signing'
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
     compile "org.apache.httpcomponents:httpcore:4.4.5"
-    compile "org.apache.httpcomponents:httpclient:4.5.8"
+    compile "org.apache.httpcomponents:httpclient:4.5.10"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.easymock:easymock:4.0.1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updates internal usage of testing frameworks to new testclusters framework
* Updates where jacoco dumps execution data coverage as gradle tasks were removed
* Removes multi node task and replaces with project property that can be used on run or integTest tasks
* Updates tests that were failing multi-node integration tests
* Updates debugging functionality, can debug multi-node integration tests and run task
* Updates README
* Adds task tree utility dependency so I don't have to keep adding it when I want to see the task tree
* Updates httpclient dependency
* Fixes stats API being broken on multi-node cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
