### PR TITLE
JAVA_HOME path corrected

### DIFF
--- a/.github/workflows/push-notification-jar.yml
+++ b/.github/workflows/push-notification-jar.yml
@@ -41,4 +41,4 @@ jobs:
           
           cd alerting/notification
           
-          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=/opt/hostedtoolcache/jdk/13.0.2/x64/lib/security/cacerts
+          ../gradlew publishShadowPublicationToSonatype-stagingRepository -Dcompiler.java=13 -Dbuild.snapshot=false -Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts


### PR DESCRIPTION
*Issue #, if available:* Workflow [failure](https://github.com/opendistro-for-elasticsearch/alerting/actions/runs/95792328)

*Description of changes:* Modified JAVA_HOME path and [tested](https://github.com/gaiksaya/alerting/runs/676539202?check_suite_focus=true)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
