### PR TITLE
Change default value of the index rollover condition

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
@@ -91,7 +91,7 @@ class AlertingSettings {
 
         val ALERT_HISTORY_INDEX_MAX_AGE = Setting.positiveTimeSetting(
                 "opendistro.alerting.alert_history_max_age",
-                TimeValue.timeValueHours(24),
+                TimeValue(30, TimeUnit.DAYS),
                 Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
@@ -104,7 +104,7 @@ class AlertingSettings {
 
         val ALERT_HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
                 "opendistro.alerting.alert_history_retention_period",
-                TimeValue(30, TimeUnit.DAYS),
+                TimeValue(60, TimeUnit.DAYS),
                 Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, the default value of `alert_history_max_age` is 24 hours, which may lead to create small index everyday, and those indices are small in size and can cause shard skew on a node while relocation.

- Change default value of the setting `alert_history_max_age` to 30 days
- Change default value of the setting `alert_history_retention_period` to 60 days


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
