### PR TITLE
Backport to 1.8 - Change default value of the index rollover condition (#206)

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/settings/AlertingSettings.kt
@@ -91,7 +91,7 @@ class AlertingSettings {
 
         val ALERT_HISTORY_INDEX_MAX_AGE = Setting.positiveTimeSetting(
                 "opendistro.alerting.alert_history_max_age",
-                TimeValue.timeValueHours(24),
+                TimeValue(30, TimeUnit.DAYS),
                 Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 
@@ -104,7 +104,7 @@ class AlertingSettings {
 
         val ALERT_HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
                 "opendistro.alerting.alert_history_retention_period",
-                TimeValue(30, TimeUnit.DAYS),
+                TimeValue(60, TimeUnit.DAYS),
                 Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Backport the changes in PR https://github.com/opendistro-for-elasticsearch/alerting/pull/206:
* change default value of the setting 'alert_history_max_age' to 30 days
* change default value of the setting 'alert_history_retention_period' to 60 days

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
