### PR TITLE
Support integration testing against remote security enabled clustering

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -97,6 +97,11 @@ integTest {
     runner {
         systemProperty 'tests.security.manager', 'false'
         systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
+
+        systemProperty "https", System.getProperty("https")
+        systemProperty "user", System.getProperty("user")
+        systemProperty "password", System.getProperty("password")
+
         // The 'doFirst' delays till execution time.
         doFirst {
             // Tell the test JVM if the cluster JVM is running under a debugger so that tests can

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -60,7 +60,7 @@ import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
 
-abstract class AlertingRestTestCase : ESRestTestCase() {
+abstract class AlertingRestTestCase : ODFERestTestCase() {
 
     private val isDebuggingTest = DisableOnDebug(null).isDebugging
     private val isDebuggingRemoteCluster = System.getProperty("cluster.debug", "false")!!.toBoolean()

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -47,7 +47,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent
 import org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.search.SearchModule
-import org.elasticsearch.test.rest.ESRestTestCase
 import org.junit.AfterClass
 import org.junit.rules.DisableOnDebug
 import java.net.URLEncoder

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -99,7 +99,7 @@ abstract class ODFERestTestCase : ESRestTestCase() {
         builder.setDefaultHeaders(defaultHeaders)
         builder.setHttpClientConfigCallback { httpClientBuilder: HttpAsyncClientBuilder ->
             val userName = System.getProperty("user")
-            val password =System.getProperty("password")
+            val password = System.getProperty("password")
             val credentialsProvider: CredentialsProvider = BasicCredentialsProvider()
             credentialsProvider.setCredentials(AuthScope.ANY, UsernamePasswordCredentials(userName, password))
             try {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -39,7 +39,6 @@ import org.elasticsearch.test.rest.ESRestTestCase
 import org.junit.After
 import java.io.IOException
 import java.security.cert.X509Certificate
-import java.util.*
 
 abstract class ODFERestTestCase : ESRestTestCase() {
 
@@ -56,7 +55,7 @@ abstract class ODFERestTestCase : ESRestTestCase() {
     }
 
     override fun preserveIndicesUponCompletion(): Boolean {
-        return true;
+        return true
     }
 
     @Throws(IOException::class)
@@ -71,11 +70,11 @@ abstract class ODFERestTestCase : ESRestTestCase() {
             for (index in parser.list()) {
                 val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
                 val indexName: String = jsonObject["index"] as String
-                //.opendistro_security isn't allowed to delete from cluster
+                // .opendistro_security isn't allowed to delete from cluster
                 if (".opendistro_security" != indexName) {
                     client().performRequest(Request("DELETE", "/$indexName"))
                 }
-            }}
+            } }
     }
     @Throws(IOException::class)
     override fun buildClient(settings: Settings, hosts: Array<HttpHost>): RestClient {
@@ -99,15 +98,13 @@ abstract class ODFERestTestCase : ESRestTestCase() {
         }
         builder.setDefaultHeaders(defaultHeaders)
         builder.setHttpClientConfigCallback { httpClientBuilder: HttpAsyncClientBuilder ->
-            val userName = Optional.ofNullable(System.getProperty("user"))
-                    .orElseThrow { RuntimeException("user name is missing") }
-            val password = Optional.ofNullable(System.getProperty("password"))
-                    .orElseThrow { RuntimeException("password is missing") }
+            val userName = System.getProperty("user")
+            val password =System.getProperty("password")
             val credentialsProvider: CredentialsProvider = BasicCredentialsProvider()
             credentialsProvider.setCredentials(AuthScope.ANY, UsernamePasswordCredentials(userName, password))
             try {
                 return@setHttpClientConfigCallback httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
-                        //disable the certificate since our testing cluster just uses the default security configuration
+                        // disable the certificate since our testing cluster just uses the default security configuration
                         .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                         .setSSLContext(SSLContextBuilder.create()
                                 .loadTrustMaterial(null) { chains: Array<X509Certificate?>?, authType: String? -> true }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -107,7 +107,7 @@ abstract class ODFERestTestCase : ESRestTestCase() {
                         // disable the certificate since our testing cluster just uses the default security configuration
                         .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                         .setSSLContext(SSLContextBuilder.create()
-                                .loadTrustMaterial(null) { chains: Array<X509Certificate?>?, authType: String? -> true }
+                                .loadTrustMaterial(null) { _: Array<X509Certificate?>?, _: String? -> true }
                                 .build())
             } catch (e: Exception) {
                 throw RuntimeException(e)

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -65,7 +65,6 @@ abstract class ODFERestTestCase : ESRestTestCase() {
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
 
         val xContentType = XContentType.fromMediaTypeOrFormat(response.entity.contentType.value)
-        // EMPTY and THROW are fine here because `.map` doesn't use named x content or deprecation
         xContentType.xContent().createParser(
                 NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
                 response.entity.content).use { parser ->

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -1,0 +1,127 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting
+
+import org.apache.http.Header
+import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.client.CredentialsProvider
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.conn.ssl.NoopHostnameVerifier
+import org.apache.http.impl.client.BasicCredentialsProvider
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
+import org.apache.http.message.BasicHeader
+import org.apache.http.ssl.SSLContextBuilder
+import org.elasticsearch.client.Request
+import org.elasticsearch.client.RestClient
+import org.elasticsearch.client.RestClientBuilder
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.unit.TimeValue
+import org.elasticsearch.common.util.concurrent.ThreadContext
+import org.elasticsearch.common.xcontent.DeprecationHandler
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.test.rest.ESRestTestCase
+import org.junit.After
+import java.io.IOException
+import java.security.cert.X509Certificate
+import java.util.*
+
+abstract class ODFERestTestCase : ESRestTestCase() {
+
+    private fun isHttps(): Boolean {
+        return System.getProperty("https", "false")!!.toBoolean()
+    }
+
+    override fun getProtocol(): String {
+        return if (isHttps()) {
+            "https"
+        } else {
+            "http"
+        }
+    }
+
+    override fun preserveIndicesUponCompletion(): Boolean {
+        return true;
+    }
+
+    @Throws(IOException::class)
+    @After
+    public open fun wipeAllODFEIndices() {
+        val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
+
+        val xContentType = XContentType.fromMediaTypeOrFormat(response.entity.contentType.value)
+        // EMPTY and THROW are fine here because `.map` doesn't use named x content or deprecation
+        xContentType.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                response.entity.content).use { parser ->
+            for (index in parser.list()) {
+                val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
+                val indexName: String = jsonObject["index"] as String
+                //.opendistro_security isn't allowed to delete from cluster
+                if (".opendistro_security" != indexName) {
+                    client().performRequest(Request("DELETE", "/$indexName"))
+                }
+            }}
+    }
+    @Throws(IOException::class)
+    override fun buildClient(settings: Settings, hosts: Array<HttpHost>): RestClient {
+        val builder = RestClient.builder(*hosts)
+        if (isHttps()) {
+            configureHttpsClient(builder, settings)
+        } else {
+            configureClient(builder, settings)
+        }
+        builder.setStrictDeprecationMode(true)
+        return builder.build()
+    }
+
+    @Throws(IOException::class)
+    protected open fun configureHttpsClient(builder: RestClientBuilder, settings: Settings) {
+        val headers = ThreadContext.buildDefaultHeaders(settings)
+        val defaultHeaders = arrayOfNulls<Header>(headers.size)
+        var i = 0
+        for ((key, value) in headers) {
+            defaultHeaders[i++] = BasicHeader(key, value)
+        }
+        builder.setDefaultHeaders(defaultHeaders)
+        builder.setHttpClientConfigCallback { httpClientBuilder: HttpAsyncClientBuilder ->
+            val userName = Optional.ofNullable(System.getProperty("user"))
+                    .orElseThrow { RuntimeException("user name is missing") }
+            val password = Optional.ofNullable(System.getProperty("password"))
+                    .orElseThrow { RuntimeException("password is missing") }
+            val credentialsProvider: CredentialsProvider = BasicCredentialsProvider()
+            credentialsProvider.setCredentials(AuthScope.ANY, UsernamePasswordCredentials(userName, password))
+            try {
+                return@setHttpClientConfigCallback httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+                        //disable the certificate since our testing cluster just uses the default security configuration
+                        .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                        .setSSLContext(SSLContextBuilder.create()
+                                .loadTrustMaterial(null) { chains: Array<X509Certificate?>?, authType: String? -> true }
+                                .build())
+            } catch (e: Exception) {
+                throw RuntimeException(e)
+            }
+        }
+        val socketTimeoutString = settings[CLIENT_SOCKET_TIMEOUT]
+        val socketTimeout = TimeValue.parseTimeValue(socketTimeoutString ?: "60s", CLIENT_SOCKET_TIMEOUT)
+        builder.setRequestConfigCallback { conf: RequestConfig.Builder -> conf.setSocketTimeout(Math.toIntExact(socketTimeout.millis)) }
+        if (settings.hasValue(CLIENT_PATH_PREFIX)) {
+            builder.setPathPrefix(settings[CLIENT_PATH_PREFIX])
+        }
+    }
+}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
@@ -49,7 +49,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         assertIndexExists(AlertIndices.HISTORY_WRITE_INDEX)
         verifyIndexSchemaVersion(AlertIndices.ALERT_INDEX, 0)
         verifyIndexSchemaVersion(AlertIndices.HISTORY_WRITE_INDEX, 0)
-        client().makeRequest("DELETE", ".*")
+        wipeAllODFEIndices()
         executeMonitor(createRandomMonitor())
         assertIndexExists(AlertIndices.ALERT_INDEX)
         assertIndexExists(AlertIndices.HISTORY_WRITE_INDEX)
@@ -65,8 +65,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         executeMonitor(trueMonitor)
         assertIndexExists(AlertIndices.ALERT_INDEX)
         assertIndexExists(AlertIndices.HISTORY_WRITE_INDEX)
-
-        client().makeRequest("DELETE", ".*")
+        wipeAllODFEIndices()
         assertIndexDoesNotExist(AlertIndices.ALERT_INDEX)
         assertIndexDoesNotExist(AlertIndices.HISTORY_WRITE_INDEX)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is to support integration testing against remote security enabled clustering. currently we only support the integration testing without security plugin. see details here:
https://quip-amazon.com/abtrAOGuqcA1/Investigation-Hooked-Plugin-IT-against-Security-Enabled-Cluster-in-ODFE-Building-Workflow

I just used alerting plugin for the investigation This PR has all the changes of investigation to support IT with admin user. It won't cover the specific security related new cases, but this change enables us to run the existing test cases against security enabled cluster. 
Feel free to close this PR :) if this isn't right way for alerting plugin.

And btw, this is my first time to write kotlin codes. pls share our comments for any issue, thanks.

*Testing:*
run those following commands successfully: 
 * ./gradlew build
 *  ../gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin 
    * this need set up a local odfe cluster with security plugin




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
