### PR TITLE
Adds supports for ES 7.7.1

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -84,6 +84,8 @@ javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code
 licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
+// TODO - enable
+validateNebulaPom.enabled = false
 
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
 es_tmp_dir.mkdirs()

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -84,7 +84,7 @@ javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code
 licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
-// TODO - enable
+// no need to validate pom, as this project is not uploaded to sonatype
 validateNebulaPom.enabled = false
 
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        es_version = '7.7.0'
+        es_version = '7.7.1'
         kotlin_version = '1.3.21'
     }
 
@@ -42,7 +42,7 @@ apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
-    opendistroVersion = '1.8.0'
+    opendistroVersion = '1.8.1'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -85,7 +85,7 @@ publishing {
     repositories {
         maven {
             name = "sonatype-staging"
-            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            url "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2"
             credentials {
                 username project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : ''
                 password project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : ''


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump ODFE version to 1.8.1
- Bump Elasticsearch version to 7.7.1
- Bump Gradle version to 6.4.1
- Disable the 'validateNebulaPom' task for the sub-projects that are not uploaded to sonatype, due to 'POM validation' are added by ES, which requires 'lisences' and 'developers' elements in POM file. (https://github.com/elastic/elasticsearch/pull/55272)
- Use new Maven endpoint URL for ODFE (https://github.com/opendistro-for-elasticsearch/alerting/issues/214)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
