### PR TITLE
Adds support for ES 7.8.0

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -81,8 +81,10 @@ dependencies {
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code
-licenseHeaders.enabled = true
+licenseHeaders.enabled = false
 dependencyLicenses.enabled = false
+// no need to validate pom, as this project is not uploaded to sonatype
+validateNebulaPom.enabled = false
 thirdPartyAudit.enabled = false
 
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 // no need to validate pom, as this project is not uploaded to sonatype
 validateNebulaPom.enabled = false

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -57,6 +57,7 @@ import org.elasticsearch.painless.spi.WhitelistLoader
 import org.elasticsearch.plugins.ActionPlugin
 import org.elasticsearch.plugins.Plugin
 import org.elasticsearch.plugins.ScriptPlugin
+import org.elasticsearch.repositories.RepositoriesService
 import org.elasticsearch.rest.RestController
 import org.elasticsearch.rest.RestHandler
 import org.elasticsearch.script.ScriptContext
@@ -131,7 +132,8 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, P
         environment: Environment,
         nodeEnvironment: NodeEnvironment,
         namedWriteableRegistry: NamedWriteableRegistry,
-        indexNameExpressionResolver: IndexNameExpressionResolver
+        indexNameExpressionResolver: IndexNameExpressionResolver,
+        repositoriesServiceSupplier: Supplier<RepositoriesService>?
     ): Collection<Any> {
         // Need to figure out how to use the Elasticsearch DI classes rather than handwiring things here.
         val settings = environment.settings()

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -133,7 +133,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, P
         nodeEnvironment: NodeEnvironment,
         namedWriteableRegistry: NamedWriteableRegistry,
         indexNameExpressionResolver: IndexNameExpressionResolver,
-        repositoriesServiceSupplier: Supplier<RepositoriesService>?
+        repositoriesServiceSupplier: Supplier<RepositoriesService>
     ): Collection<Any> {
         // Need to figure out how to use the Elasticsearch DI classes rather than handwiring things here.
         val settings = environment.settings()

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndices.kt
@@ -158,7 +158,7 @@ class AlertIndices(
     override fun clusterChanged(event: ClusterChangedEvent) {
         // if the indexes have been deleted they need to be reinitalized
         alertIndexInitialized = event.state().routingTable().hasIndex(ALERT_INDEX)
-        historyIndexInitialized = event.state().metaData().hasAlias(HISTORY_WRITE_INDEX)
+        historyIndexInitialized = event.state().metadata().hasAlias(HISTORY_WRITE_INDEX)
     }
 
     private fun rescheduleRollover() {
@@ -265,7 +265,7 @@ class AlertIndices(
                 .settings(Settings.builder().put("index.hidden", true).build())
         request.addMaxIndexDocsCondition(historyMaxDocs)
         request.addMaxIndexAgeCondition(historyMaxAge)
-        val response = client.admin().indices().rolloversIndex(request).actionGet(requestTimeout)
+        val response = client.admin().indices().rolloverIndex(request).actionGet(requestTimeout)
         if (!response.isRolledOver) {
             logger.info("$HISTORY_WRITE_INDEX not rolled over. Conditions were: ${response.conditionStatus}")
         } else {
@@ -280,13 +280,13 @@ class AlertIndices(
         val clusterStateRequest = ClusterStateRequest()
                 .clear()
                 .indices(HISTORY_ALL)
-                .metaData(true)
+                .metadata(true)
                 .local(true)
                 .indicesOptions(IndicesOptions.strictExpand())
 
         val clusterStateResponse = client.admin().cluster().state(clusterStateRequest).actionGet()
 
-        for (entry in clusterStateResponse.state.metaData.indices) {
+        for (entry in clusterStateResponse.state.metadata.indices) {
             val indexMetaData = entry.value
             val creationTime = indexMetaData.creationDate
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtils.kt
@@ -22,7 +22,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.IndicesAdminClient
 import org.elasticsearch.cluster.ClusterState
-import org.elasticsearch.cluster.metadata.IndexMetaData
+import org.elasticsearch.cluster.metadata.IndexMetadata
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
 import org.elasticsearch.common.xcontent.NamedXContentRegistry
 import org.elasticsearch.common.xcontent.XContentParser
@@ -92,11 +92,11 @@ class IndexUtils {
 
         @JvmStatic
         fun getIndexNameWithAlias(clusterState: ClusterState, alias: String): String {
-            return clusterState.metaData.indices.first { it.value.aliases.containsKey(alias) }.key
+            return clusterState.metadata.indices.first { it.value.aliases.containsKey(alias) }.key
         }
 
         @JvmStatic
-        fun shouldUpdateIndex(index: IndexMetaData, mapping: String): Boolean {
+        fun shouldUpdateIndex(index: IndexMetadata, mapping: String): Boolean {
             var oldVersion = NO_SCHEMA_VERSION
             val newVersion = getSchemaVersion(mapping)
 
@@ -119,8 +119,8 @@ class IndexUtils {
             client: IndicesAdminClient,
             actionListener: ActionListener<AcknowledgedResponse>
         ) {
-            if (clusterState.metaData.indices.containsKey(index)) {
-                if (shouldUpdateIndex(clusterState.metaData.indices[index], mapping)) {
+            if (clusterState.metadata.indices.containsKey(index)) {
+                if (shouldUpdateIndex(clusterState.metadata.indices[index], mapping)) {
                     val putMappingRequest: PutMappingRequest = PutMappingRequest(index).type(type).source(mapping, XContentType.JSON)
                     client.putMapping(putMappingRequest, actionListener)
                 } else {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtilsTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/IndexUtilsTests.kt
@@ -16,7 +16,7 @@
 package com.amazon.opendistroforelasticsearch.alerting.util
 
 import com.amazon.opendistroforelasticsearch.alerting.parser
-import org.elasticsearch.cluster.metadata.IndexMetaData
+import org.elasticsearch.cluster.metadata.IndexMetadata
 import org.elasticsearch.test.ESTestCase
 import java.lang.NumberFormatException
 import kotlin.test.assertFailsWith
@@ -66,7 +66,7 @@ class IndexUtilsTests : ESTestCase() {
                 "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mapping_version\":123," +
                 "\"settings_version\":123,\"mappings\":{\"_doc\":{\"properties\":{\"name\":{\"type\":\"keyword\"}}}}}}"
         val newMapping = "{\"_meta\":{\"schema_version\":10},\"properties\":{\"name\":{\"type\":\"keyword\"}}}"
-        val index: IndexMetaData = IndexMetaData.fromXContent(parser(indexContent))
+        val index: IndexMetadata = IndexMetadata.fromXContent(parser(indexContent))
 
         val shouldUpdateIndex = IndexUtils.shouldUpdateIndex(index, newMapping)
         assertTrue(shouldUpdateIndex)
@@ -79,7 +79,7 @@ class IndexUtilsTests : ESTestCase() {
                 "\"settings_version\":123,\"mappings\":{\"_doc\":{\"_meta\":{\"schema_version\":1},\"properties\":" +
                 "{\"name\":{\"type\":\"keyword\"}}}}}}"
         val newMapping = "{\"_meta\":{\"schema_version\":10},\"properties\":{\"name\":{\"type\":\"keyword\"}}}"
-        val index: IndexMetaData = IndexMetaData.fromXContent(parser(indexContent))
+        val index: IndexMetadata = IndexMetadata.fromXContent(parser(indexContent))
 
         val shouldUpdateIndex = IndexUtils.shouldUpdateIndex(index, newMapping)
         assertTrue(shouldUpdateIndex)
@@ -91,7 +91,7 @@ class IndexUtilsTests : ESTestCase() {
                 "\"version\":{\"created\":\"6040399\"},\"provided_name\":\"data_test\"}},\"mappings\":" +
                 "{\"_doc\":{\"_meta\":{\"schema_version\":1},\"properties\":{\"name\":{\"type\":\"keyword\"}}}}}}"
         val newMapping = "{\"_meta\":{\"schema_version\":1},\"properties\":{\"name\":{\"type\":\"keyword\"}}}"
-        val index: IndexMetaData = IndexMetaData.fromXContent(parser(indexContent))
+        val index: IndexMetadata = IndexMetadata.fromXContent(parser(indexContent))
 
         val shouldUpdateIndex = IndexUtils.shouldUpdateIndex(index, newMapping)
         assertFalse(shouldUpdateIndex)

--- a/build-tools/esplugin-coverage.gradle
+++ b/build-tools/esplugin-coverage.gradle
@@ -56,7 +56,8 @@ integTest.runner {
 }
 
 testClusters.integTest {
-    jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}"
+    //Hack: to fix jacocoagent path with gradle 6.5, add the missing "/" at the start of the jacocoagent path.
+    jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}".replace('javaagent:','javaagent:/')
     systemProperty 'com.sun.management.jmxremote', "true"
     systemProperty 'com.sun.management.jmxremote.authenticate', "false"
     systemProperty 'com.sun.management.jmxremote.port', "7777"

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ allprojects {
 }
 
 
-
 evaluationDependsOnChildren()
 
 check.dependsOn subprojects*.check

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ allprojects {
     }
 }
 
-
 evaluationDependsOnChildren()
 
 check.dependsOn subprojects*.check

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     apply from: 'build-tools/repositories.gradle'
 
     ext {
-        es_version = '7.7.0'
+        es_version = '7.8.0'
         kotlin_version = '1.3.21'
     }
 
@@ -42,7 +42,7 @@ apply plugin: 'jacoco'
 apply from: 'build-tools/merged-coverage.gradle'
 
 ext {
-    opendistroVersion = '1.8.0'
+    opendistroVersion = '1.9.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -61,6 +61,8 @@ allprojects {
         compileKotlin.kotlinOptions.jvmTarget = compileTestKotlin.kotlinOptions.jvmTarget = "1.8"
     }
 }
+
+
 
 evaluationDependsOnChildren()
 

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/ScheduledJobIndices.kt
@@ -67,7 +67,7 @@ class ScheduledJobIndices(private val client: AdminClient, private val clusterSe
 
         if (scheduledJobIndexExists()) {
             val indexRoutingTable = clusterService.state().routingTable.index(ScheduledJob.SCHEDULED_JOBS_INDEX)
-            val indexMetaData = clusterService.state().metaData().index(ScheduledJob.SCHEDULED_JOBS_INDEX)
+            val indexMetaData = clusterService.state().metadata().index(ScheduledJob.SCHEDULED_JOBS_INDEX)
 
             indexHealth = ClusterIndexHealth(indexMetaData, indexRoutingTable)
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -18,6 +18,7 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'elasticsearch.testclusters'
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
@@ -44,6 +45,8 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
+
+
 
 publishing {
     publications {
@@ -85,7 +88,7 @@ publishing {
     repositories {
         maven {
             name = "sonatype-staging"
-            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            url "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2"
             credentials {
                 username project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : ''
                 password project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : ''

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -45,7 +45,6 @@ task javadocJar(type: Jar) {
     from javadoc.destinationDir
 }
 
-
 publishing {
     publications {
         shadow(MavenPublication) {

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'elasticsearch.testclusters'
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
@@ -45,7 +44,6 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
-
 
 
 publishing {

--- a/release-notes/opendistro-for-elasticsearch.alerting.release-notes-1.9.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch.alerting.release-notes-1.9.0.0.md
@@ -1,0 +1,4 @@
+## 2020-06-24, Version 1.9.0.0
+
+### New Features
+  * Adds support for Elasticsearch 7.8.0 - [PR #219](https://github.com/opendistro-for-elasticsearch/alerting/pull/219)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/alerting/issues/218

*Description of changes:*
- Bump ODFE version to 1.9.0
- Bump Elasticsearch version to 7.8.0
- Bump Gradle version to 6.5
- Changes to Alerting plugin code to make it compatible with Elasticsearch 7.8.0 data structures. 
- Fix jacocoagent path to work with gradle 6.5 for integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
