### PR TITLE
Add coverage upload in test workflow and add badges in README

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,7 +1,11 @@
 name: Test Workflow
-# This workflow is triggered on pull requests to master or a opendistro release branch
+# This workflow is triggered on pull requests and pushes to master or an opendistro release branch
 on:
   pull_request:
+    branches:
+      - master
+      - opendistro-*
+  push:
     branches:
       - master
       - opendistro-*
@@ -30,6 +34,11 @@ jobs:
         run: |
           mkdir -p alerting-artifacts
           cp ./alerting/build/distributions/*.zip alerting-artifacts
+      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[![Test Workflow](https://github.com/opendistro-for-elasticsearch/alerting/workflows/Test%20Workflow/badge.svg)](https://github.com/opendistro-for-elasticsearch/alerting/actions)
+[![codecov](https://codecov.io/gh/opendistro-for-elasticsearch/alerting/branch/master/graph/badge.svg)](https://codecov.io/gh/opendistro-for-elasticsearch/alerting)
+[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/api/)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/alerting/)
+![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
+
+
 # Open Distro for Elasticsearch Alerting
 
 The Open Distro for Elasticsearch Alerting enables you to monitor your data and send alert notifications automatically to your stakeholders. With an intuitive Kibana interface and a powerful API, it is easy to set up, manage, and monitor your alerts. Craft highly specific alert conditions using Elasticsearch's full query language and scripting capabilities.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 - Use Codecov to visualize the code coverage result 
 - Add Coverage Report Upload action in `test-workflow`
 - Add several badges in README

This PR carries the code coverage visualization that already in `index-management` repo to `alerting`
https://github.com/opendistro-for-elasticsearch/index-management/pull/230
https://github.com/opendistro-for-elasticsearch/index-management/pull/231
https://github.com/opendistro-for-elasticsearch/index-management/pull/232

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
