### PR TITLE
Backport: Fix stats API being broken on multi-node cluster

### DIFF
--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/action/node/ScheduledJobStats.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/core/action/node/ScheduledJobStats.kt
@@ -46,8 +46,8 @@ class ScheduledJobStats : BaseNodeResponse, ToXContentFragment {
 
     constructor(si: StreamInput): super(si) {
         this.status = si.readEnum(ScheduleStatus::class.java)
-        this.jobSweeperMetrics = JobSweeperMetrics(si)
-        this.jobInfos = si.readList { JobSchedulerMetrics(it) }.toTypedArray()
+        this.jobSweeperMetrics = si.readOptionalWriteable { JobSweeperMetrics(it) }
+        this.jobInfos = si.readOptionalArray({ sti: StreamInput -> JobSchedulerMetrics(sti) }, { size -> arrayOfNulls(size) })
     }
 
     constructor(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backport the the fix for Monitor stats API on multi-node cluster.

The Monitor stats API (`GET _opendistro/_alerting/stats`) broke in multi-node cluster when upgrading the plugin to ES 7.4
Related PRs: https://github.com/opendistro-for-elasticsearch/alerting/pull/141, https://github.com/opendistro-for-elasticsearch/alerting/pull/142
 
It was caught in https://github.com/opendistro-for-elasticsearch/alerting/pull/185 when upgrading to ES 7.5 when testing multi node
> Fixes stats API being broken on multi-node cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
