### PR TITLE
Upgrade the vulnerable version of dependencices - Kotlin and 'commons-codec'

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -58,9 +58,10 @@ configurations.all {
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
         force "commons-logging:commons-logging:${versions.commonslogging}"
         force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-        force "commons-codec:commons-codec:${versions.commonscodec}"
+        // force the version until Elasticsearch upgrade to an invulnerable one, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
+        force "commons-codec:commons-codec:1.13"
         
-        // This is required because kotlin coroutines core-1.1.1 still requires kotin stdlib 1.3.20 and we're using 1.3.21
+        // This is required because kotlin-coroutines-core 1.1.1 still requires kotlin stdlib 1.3.20 and we're using a higher kotlin version
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
     ext {
         es_version = '7.8.0'
-        kotlin_version = '1.3.21'
+        kotlin_version = '1.3.72'
     }
 
     repositories {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some current dependencies have got the following vulnerabilities, and this PR will upgrade the versions.
1. kotlin stdlib 1.3.21
https://www.whitesourcesoftware.com/vulnerability-database/CVE-2019-10101
https://www.whitesourcesoftware.com/vulnerability-database/CVE-2019-10102
https://www.whitesourcesoftware.com/vulnerability-database/CVE-2019-10103
Will update Kotlin to the latest stable version: 1.3.72.
2. commons-codec 1.11
https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
Will update to the first release that fix the vulnerability: 1.13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
