### PR TITLE
Change release workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -51,11 +51,25 @@ jobs:
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts to S3
         run: |
-          s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp alerting-artifacts/*.zip $s3_path/elasticsearch-plugins/opendistro-alerting/
-          aws s3 cp alerting-artifacts/*.deb $s3_path/debs/opendistro-alerting/
-          aws s3 cp alerting-artifacts/*.rpm $s3_path/rpms/opendistro-alerting/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
+          zip=`ls alerting-artifacts/*.zip`
+          rpm=`ls alerting-artifacts/*.rpm`
+          deb=`ls alerting-artifacts/*.deb`
+
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/elasticsearch-plugins/alerting/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+
+          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 
       - name: Create Github Draft Release
         id: create_release


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS REQUEST UNTIL ASKED. We need to coordinate the merge with updating Github secrets.

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com. The write to S3 currently fails (see https://github.com/camerski/alerting/actions/runs/305062956) because the secrets have not been updated; the secrets will be updated at the same time this PR is merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
