### PR TITLE
Allow empty notification responses

### DIFF
--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/response/DestinationResponse.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/response/DestinationResponse.java
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.alerting.destination.response;
 
-import org.elasticsearch.common.Strings;
-
 /**
  * This class is a place holder for destination response metadata
  */
@@ -26,7 +24,7 @@ public class DestinationResponse extends BaseResponse {
 
     private DestinationResponse(final String responseString, final int statusCode) {
         super(statusCode);
-        if (Strings.isNullOrEmpty(responseString)) {
+        if (responseString == null) {
             throw new IllegalArgumentException("Response is missing");
         }
         this.responseContent = responseString;

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/SlackDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/SlackDestinationTest.java
@@ -24,6 +24,7 @@ import com.amazon.opendistroforelasticsearch.alerting.destination.message.SlackM
 import com.amazon.opendistroforelasticsearch.alerting.destination.response.DestinationResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.easymock.EasyMock;
@@ -36,12 +37,14 @@ import static org.junit.Assert.assertEquals;
 public class SlackDestinationTest {
 
     @Test
-    public void testSlackMessage() throws Exception {
-
+    public void testSlackMessage_NullEntityResponse() throws Exception {
         CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
 
-        DestinationResponse expectedSlackResponse = new DestinationResponse.Builder().withResponseContent("{}")
-                .withStatusCode(RestStatus.OK.getStatus()).build();
+        // The DestinationHttpClient replaces a null entity with "{}".
+        DestinationResponse expectedSlackResponse = new DestinationResponse.Builder()
+                .withResponseContent("{}")
+                .withStatusCode(RestStatus.OK.getStatus())
+                .build();
         CloseableHttpResponse httpResponse = EasyMock.createMock(CloseableHttpResponse.class);
         EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost.class))).andReturn(httpResponse);
 
@@ -49,6 +52,86 @@ public class SlackDestinationTest {
 
         EasyMock.expect(httpResponse.getStatusLine()).andReturn(mockStatusLine);
         EasyMock.expect(httpResponse.getEntity()).andReturn(null).anyTimes();
+        EasyMock.expect(mockStatusLine.getStatusCode()).andReturn(RestStatus.OK.getStatus());
+        EasyMock.replay(mockHttpClient);
+        EasyMock.replay(httpResponse);
+        EasyMock.replay(mockStatusLine);
+
+        DestinationHttpClient httpClient = new DestinationHttpClient();
+        httpClient.setHttpClient(mockHttpClient);
+        SlackDestinationFactory slackDestinationFactory = new SlackDestinationFactory();
+        slackDestinationFactory.setClient(httpClient);
+
+        DestinationFactoryProvider.setFactory(DestinationType.SLACK, slackDestinationFactory);
+
+        String message = "{\"text\":\"Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present\"}";
+        BaseMessage bm = new SlackMessage.Builder("abc").withMessage(message).
+                withUrl("https://hooks.slack.com/services/xxxx/xxxxxx/xxxxxxxxx").build();
+
+        DestinationResponse actualSlackResponse = (DestinationResponse) Notification.publish(bm);
+
+        assertEquals(expectedSlackResponse.getResponseContent(), actualSlackResponse.getResponseContent());
+        assertEquals(expectedSlackResponse.getStatusCode(), actualSlackResponse.getStatusCode());
+    }
+
+    @Test
+    public void testSlackMessage_EmptyEntityResponse() throws Exception {
+        CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
+
+        DestinationResponse expectedSlackResponse = new DestinationResponse.Builder()
+                .withResponseContent("")
+                .withStatusCode(RestStatus.OK.getStatus())
+                .build();
+        CloseableHttpResponse httpResponse = EasyMock.createMock(CloseableHttpResponse.class);
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost.class))).andReturn(httpResponse);
+
+        BasicStatusLine mockStatusLine = EasyMock.createMock(BasicStatusLine.class);
+
+        EasyMock.expect(httpResponse.getStatusLine()).andReturn(mockStatusLine);
+        EasyMock.expect(httpResponse.getEntity()).andReturn(new StringEntity("")).anyTimes();
+        EasyMock.expect(mockStatusLine.getStatusCode()).andReturn(RestStatus.OK.getStatus());
+        EasyMock.replay(mockHttpClient);
+        EasyMock.replay(httpResponse);
+        EasyMock.replay(mockStatusLine);
+
+        DestinationHttpClient httpClient = new DestinationHttpClient();
+        httpClient.setHttpClient(mockHttpClient);
+        SlackDestinationFactory slackDestinationFactory = new SlackDestinationFactory();
+        slackDestinationFactory.setClient(httpClient);
+
+        DestinationFactoryProvider.setFactory(DestinationType.SLACK, slackDestinationFactory);
+
+        String message = "{\"text\":\"Vamshi Message gughjhjlkh Body emoji test: :) :+1: " +
+                "link test: http://sample.com email test: marymajor@example.com All member callout: " +
+                "@All All Present member callout: @Present\"}";
+        BaseMessage bm = new SlackMessage.Builder("abc").withMessage(message).
+                withUrl("https://hooks.slack.com/services/xxxx/xxxxxx/xxxxxxxxx").build();
+
+        DestinationResponse actualSlackResponse = (DestinationResponse) Notification.publish(bm);
+
+        assertEquals(expectedSlackResponse.getResponseContent(), actualSlackResponse.getResponseContent());
+        assertEquals(expectedSlackResponse.getStatusCode(), actualSlackResponse.getStatusCode());
+    }
+
+    @Test
+    public void testSlackMessage_NonemptyEntityResponse() throws Exception {
+        String responseContent = "It worked!";
+
+        CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
+
+        DestinationResponse expectedSlackResponse = new DestinationResponse.Builder()
+                .withResponseContent(responseContent)
+                .withStatusCode(RestStatus.OK.getStatus())
+                .build();
+        CloseableHttpResponse httpResponse = EasyMock.createMock(CloseableHttpResponse.class);
+        EasyMock.expect(mockHttpClient.execute(EasyMock.anyObject(HttpPost.class))).andReturn(httpResponse);
+
+        BasicStatusLine mockStatusLine = EasyMock.createMock(BasicStatusLine.class);
+
+        EasyMock.expect(httpResponse.getStatusLine()).andReturn(mockStatusLine);
+        EasyMock.expect(httpResponse.getEntity()).andReturn(new StringEntity(responseContent)).anyTimes();
         EasyMock.expect(mockStatusLine.getStatusCode()).andReturn(RestStatus.OK.getStatus());
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);


### PR DESCRIPTION
*Issue #, if available:* 133

*Description of changes:*
This change allows notification responses to be empty. Added unit tests to SlackDestinationTest, ChimeDestinationTest, and CustomWebhookMessageTest that cover null, empty, and non-empty response entities.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
