### PR TITLE
add user role filter for monitor on top of ad result

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Monitor.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Monitor.kt
@@ -191,7 +191,7 @@ data class Monitor(
                 when (fieldName) {
                     SCHEMA_VERSION_FIELD -> schemaVersion = xcp.intValue()
                     NAME_FIELD -> name = xcp.text()
-                    USER_FIELD -> user = User.parse(xcp)
+                    USER_FIELD -> user = if (xcp.currentToken() == Token.VALUE_NULL) null else User.parse(xcp)
                     ENABLED_FIELD -> enabled = xcp.booleanValue()
                     SCHEDULE_FIELD -> schedule = Schedule.parse(xcp)
                     INPUTS_FIELD -> {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -31,6 +31,8 @@ import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings.
 import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings.Companion.ALLOW_LIST
 import com.amazon.opendistroforelasticsearch.alerting.util.AlertingException
 import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils
+import com.amazon.opendistroforelasticsearch.alerting.util.addUserBackendRolesFilter
+import com.amazon.opendistroforelasticsearch.alerting.util.isADMonitor
 import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.commons.authuser.AuthUserRequestBuilder
 import org.apache.logging.log4j.LogManager
@@ -100,7 +102,12 @@ class TransportIndexMonitorAction @Inject constructor(
     }
 
     override fun doExecute(task: Task, request: IndexMonitorRequest, actionListener: ActionListener<IndexMonitorResponse>) {
-        checkIndicesAndExecute(client, actionListener, request)
+        if (!isADMonitor(request.monitor)) {
+            checkIndicesAndExecute(client, actionListener, request)
+        } else {
+            // check if user has access to any anomaly detector for AD monitor
+            checkAnomalyDetectorAndExecute(client, actionListener, request)
+        }
     }
 
     /**
@@ -140,6 +147,41 @@ class TransportIndexMonitorAction @Inject constructor(
                 ))
             }
         })
+    }
+
+    /**
+     * It's no reasonable to create AD monitor if the user has no access to any detector. Otherwise
+     * the monitor will not get any anomaly result. So we will check user has access to at least 1
+     * anomaly detector if they need to create AD monitor.
+     * As anomaly detector index is system index, common user has no permission to query. So we need
+     * to send REST API call to AD REST API.
+     */
+    fun checkAnomalyDetectorAndExecute(
+        client: Client,
+        actionListener: ActionListener<IndexMonitorResponse>,
+        request: IndexMonitorRequest
+    ) {
+        client.threadPool().threadContext.stashContext().use {
+            val searchSourceBuilder = SearchSourceBuilder()
+            addUserBackendRolesFilter(request.monitor.user, searchSourceBuilder)
+            val searchRequest = SearchRequest().indices(".opendistro-anomaly-detectors").source(searchSourceBuilder)
+            client.search(searchRequest, object : ActionListener<SearchResponse> {
+                override fun onResponse(response: SearchResponse?) {
+                    val totalHits = response?.hits?.totalHits?.value
+                    if (totalHits != null && totalHits > 0L) {
+                        IndexMonitorHandler(client, actionListener, request).resolveUserAndStart()
+                    } else {
+                        actionListener.onFailure(AlertingException.wrap(
+                                ElasticsearchStatusException("User has no available detectors", RestStatus.NOT_FOUND)
+                        ))
+                    }
+                }
+
+                override fun onFailure(t: Exception) {
+                    actionListener.onFailure(AlertingException.wrap(t))
+                }
+            })
+        }
     }
 
     inner class IndexMonitorHandler(

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -162,7 +162,7 @@ class TransportIndexMonitorAction @Inject constructor(
         request: IndexMonitorRequest
     ) {
         client.threadPool().threadContext.stashContext().use {
-            val searchSourceBuilder = SearchSourceBuilder()
+            val searchSourceBuilder = SearchSourceBuilder().size(0)
             addUserBackendRolesFilter(request.monitor.user, searchSourceBuilder)
             val searchRequest = SearchRequest().indices(".opendistro-anomaly-detectors").source(searchSourceBuilder)
             client.search(searchRequest, object : ActionListener<SearchResponse> {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtils.kt
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.util
+
+import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
+import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
+import org.apache.lucene.search.join.ScoreMode
+import org.elasticsearch.index.query.BoolQueryBuilder
+import org.elasticsearch.index.query.NestedQueryBuilder
+import org.elasticsearch.index.query.QueryBuilders
+import org.elasticsearch.search.builder.SearchSourceBuilder
+
+/**
+ * AD monitor is search input monitor on top of anomaly result index. This method will return
+ * true if monitor input only contains anomaly result index.
+ */
+fun isADMonitor(monitor: Monitor): Boolean {
+    // If monitor has other input than AD result index, it's not AD monitor
+    if (monitor.inputs.size != 1) {
+        return false
+    }
+    val input = monitor.inputs[0]
+    // AD monitor can only have 1 anomaly result index.
+    if (input is SearchInput && input.indices.size == 1 && input.indices[0] == ".opendistro-anomaly-results*") {
+        return true
+    }
+    return false
+}
+
+fun addUserBackendRolesFilter(user: User?, searchSourceBuilder: SearchSourceBuilder): SearchSourceBuilder {
+    var boolQueryBuilder = BoolQueryBuilder()
+    val userFieldName = "user"
+    val userBackendRoleFieldName = "user.backend_roles.keyword"
+    if (user == null) {
+        // For old monitor and detector, they have no user field
+        val userRolesFilterQuery = QueryBuilders.existsQuery(userFieldName)
+        val nestedQueryBuilder = NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None)
+        boolQueryBuilder.mustNot(nestedQueryBuilder)
+    } else if (user.backendRoles.isNullOrEmpty()) {
+        // For simple FGAC user, they may have no backend roles, these users should be able to see detectors
+        // of other users whose backend role is empty.
+        val userRolesFilterQuery = QueryBuilders.existsQuery(userBackendRoleFieldName)
+        val nestedQueryBuilder = NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None)
+
+        val userExistsQuery = QueryBuilders.existsQuery(userFieldName)
+        val userExistsNestedQueryBuilder = NestedQueryBuilder(userFieldName, userExistsQuery, ScoreMode.None)
+
+        boolQueryBuilder.mustNot(nestedQueryBuilder)
+        boolQueryBuilder.must(userExistsNestedQueryBuilder)
+    } else {
+        // For normal case, user should have backend roles.
+        val userRolesFilterQuery = QueryBuilders.termsQuery(userBackendRoleFieldName, user.backendRoles)
+        val nestedQueryBuilder = NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None)
+        boolQueryBuilder.must(nestedQueryBuilder)
+    }
+    val query = searchSourceBuilder.query()
+    if (query == null) {
+        searchSourceBuilder.query(boolQueryBuilder)
+    } else {
+        (query as BoolQueryBuilder).filter(boolQueryBuilder)
+    }
+    return searchSourceBuilder
+}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ADTestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ADTestHelpers.kt
@@ -1,0 +1,513 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.alerting
+
+import com.amazon.opendistroforelasticsearch.alerting.core.model.Input
+import com.amazon.opendistroforelasticsearch.alerting.core.model.IntervalSchedule
+import com.amazon.opendistroforelasticsearch.alerting.core.model.Schedule
+import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
+import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
+import org.elasticsearch.index.query.BoolQueryBuilder
+import org.elasticsearch.index.query.QueryBuilders
+import org.elasticsearch.script.Script
+import org.elasticsearch.search.aggregations.AggregationBuilders
+import org.elasticsearch.search.builder.SearchSourceBuilder
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.test.rest.ESRestTestCase
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+const val ANOMALY_DETECTOR_INDEX = ".opendistro-anomaly-detectors"
+const val ANOMALY_RESULT_INDEX = ".opendistro-anomaly-results*"
+
+fun anomalyDetectorIndexMapping(): String {
+    return """
+        "properties": {
+    "schema_version": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "description": {
+      "type": "text"
+    },
+    "time_field": {
+      "type": "keyword"
+    },
+    "indices": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "filter_query": {
+      "type": "object",
+      "enabled": false
+    },
+    "feature_attributes": {
+      "type": "nested",
+      "properties": {
+        "feature_id": {
+          "type": "keyword",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "feature_name": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "feature_enabled": {
+          "type": "boolean"
+        },
+        "aggregation_query": {
+          "type": "object",
+          "enabled": false
+        }
+      }
+    },
+    "detection_interval": {
+      "properties": {
+        "period": {
+          "properties": {
+            "interval": {
+              "type": "integer"
+            },
+            "unit": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "window_delay": {
+      "properties": {
+        "period": {
+          "properties": {
+            "interval": {
+              "type": "integer"
+            },
+            "unit": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "shingle_size": {
+      "type": "integer"
+    },
+    "last_update_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "ui_metadata": {
+      "type": "object",
+      "enabled": false
+    },
+    "user": {
+      "type": "nested",
+      "properties": {
+        "name": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "backend_roles": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        "roles": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        "custom_attribute_names": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      }
+    },
+    "category_field": {
+      "type": "keyword"
+    }
+  }
+        """
+}
+
+fun anomalyResultIndexMapping(): String {
+    return """
+            "properties": {
+              "detector_id": {
+                "type": "keyword"
+              },
+              "is_anomaly": {
+                "type": "boolean"
+              },
+              "anomaly_score": {
+                "type": "double"
+              },
+              "anomaly_grade": {
+                "type": "double"
+              },
+              "confidence": {
+                "type": "double"
+              },
+              "feature_data": {
+                "type": "nested",
+                "properties": {
+                  "feature_id": {
+                    "type": "keyword"
+                  },
+                  "data": {
+                    "type": "double"
+                  }
+                }
+              },
+              "data_start_time": {
+                "type": "date",
+                "format": "strict_date_time||epoch_millis"
+              },
+              "data_end_time": {
+                "type": "date",
+                "format": "strict_date_time||epoch_millis"
+              },
+              "execution_start_time": {
+                "type": "date",
+                "format": "strict_date_time||epoch_millis"
+              },
+              "execution_end_time": {
+                "type": "date",
+                "format": "strict_date_time||epoch_millis"
+              },
+              "error": {
+                "type": "text"
+              },
+              "user": {
+                "type": "nested",
+                "properties": {
+                  "name": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "backend_roles": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "roles": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "custom_attribute_names": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "entity": {
+                "type": "nested",
+                "properties": {
+                  "name": {
+                    "type": "keyword"
+                  },
+                  "value": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "schema_version": {
+                "type": "integer"
+              }
+            }
+        """
+}
+
+fun randomAnomalyDetector(): String {
+    return """{
+    "name" : "${ESTestCase.randomAlphaOfLength(10)}",
+    "description" : "${ESTestCase.randomAlphaOfLength(10)}",
+    "time_field" : "timestamp",
+    "indices" : [
+      "${ESTestCase.randomAlphaOfLength(5)}"
+    ],
+    "filter_query" : {
+      "match_all" : {
+        "boost" : 1.0
+      }
+    },
+    "detection_interval" : {
+      "period" : {
+        "interval" : 1,
+        "unit" : "Minutes"
+      }
+    },
+    "window_delay" : {
+      "period" : {
+        "interval" : 1,
+        "unit" : "Minutes"
+      }
+    },
+    "shingle_size" : 8,
+    "feature_attributes" : [
+      {
+        "feature_name" : "F1",
+        "feature_enabled" : true,
+        "aggregation_query" : {
+          "f_1" : {
+            "sum" : {
+              "field" : "value"
+            }
+          }
+        }
+      }
+    ]
+  }
+        """.trimIndent()
+}
+
+fun randomAnomalyDetectorWithUser(backendRole: String): String {
+    return """{
+    "name" : "${ESTestCase.randomAlphaOfLength(5)}",
+    "description" : "${ESTestCase.randomAlphaOfLength(10)}",
+    "time_field" : "timestamp",
+    "indices" : [
+      "${ESTestCase.randomAlphaOfLength(5)}"
+    ],
+    "filter_query" : {
+      "match_all" : {
+        "boost" : 1.0
+      }
+    },
+    "detection_interval" : {
+      "period" : {
+        "interval" : 1,
+        "unit" : "Minutes"
+      }
+    },
+    "window_delay" : {
+      "period" : {
+        "interval" : 1,
+        "unit" : "Minutes"
+      }
+    },
+    "shingle_size" : 8,
+    "feature_attributes" : [
+      {
+        "feature_name" : "F1",
+        "feature_enabled" : true,
+        "aggregation_query" : {
+          "f_1" : {
+            "sum" : {
+              "field" : "value"
+            }
+          }
+        }
+      }
+    ],
+    "user" : {
+      "name" : "${ESTestCase.randomAlphaOfLength(5)}",
+      "backend_roles" : [ "$backendRole" ],
+      "roles" : [
+        "${ESTestCase.randomAlphaOfLength(5)}"
+      ],
+      "custom_attribute_names" : [ ]
+    }
+  }
+        """.trimIndent()
+}
+
+fun randomAnomalyResult(
+    detectorId: String = ESTestCase.randomAlphaOfLength(10),
+    dataStartTime: Long = ZonedDateTime.now().minus(2, ChronoUnit.MINUTES).toInstant().toEpochMilli(),
+    dataEndTime: Long = ZonedDateTime.now().toInstant().toEpochMilli(),
+    featureId: String = ESTestCase.randomAlphaOfLength(5),
+    featureName: String = ESTestCase.randomAlphaOfLength(5),
+    featureData: Double = ESTestCase.randomDouble(),
+    executionStartTime: Long = ZonedDateTime.now().minus(10, ChronoUnit.SECONDS).toInstant().toEpochMilli(),
+    executionEndTime: Long = ZonedDateTime.now().toInstant().toEpochMilli(),
+    anomalyScore: Double = ESTestCase.randomDouble(),
+    anomalyGrade: Double = ESTestCase.randomDouble(),
+    confidence: Double = ESTestCase.randomDouble(),
+    user: User = randomUser()
+): String {
+    return """{
+          "detector_id" : "$detectorId",
+          "data_start_time" : $dataStartTime,
+          "data_end_time" : $dataEndTime,
+          "feature_data" : [
+            {
+              "feature_id" : "$featureId",
+              "feature_name" : "$featureName",
+              "data" : $featureData
+            }
+          ],
+          "execution_start_time" : $executionStartTime,
+          "execution_end_time" : $executionEndTime,
+          "anomaly_score" : $anomalyScore,
+          "anomaly_grade" : $anomalyGrade,
+          "confidence" : $confidence,
+          "user" : {
+            "name" : "${user.name}",
+            "backend_roles" : [
+              ${user.backendRoles.joinToString { "\"${it}\"" }}
+            ],
+            "roles" : [
+              ${user.roles.joinToString { "\"${it}\"" }}
+            ],
+            "custom_attribute_names" : [
+              ${user.customAttNames.joinToString { "\"${it}\"" }}
+            ]
+          }
+        }
+        """.trimIndent()
+}
+
+fun randomAnomalyResultWithoutUser(
+    detectorId: String = ESTestCase.randomAlphaOfLength(10),
+    dataStartTime: Long = ZonedDateTime.now().minus(2, ChronoUnit.MINUTES).toInstant().toEpochMilli(),
+    dataEndTime: Long = ZonedDateTime.now().toInstant().toEpochMilli(),
+    featureId: String = ESTestCase.randomAlphaOfLength(5),
+    featureName: String = ESTestCase.randomAlphaOfLength(5),
+    featureData: Double = ESTestCase.randomDouble(),
+    executionStartTime: Long = ZonedDateTime.now().minus(10, ChronoUnit.SECONDS).toInstant().toEpochMilli(),
+    executionEndTime: Long = ZonedDateTime.now().toInstant().toEpochMilli(),
+    anomalyScore: Double = ESTestCase.randomDouble(),
+    anomalyGrade: Double = ESTestCase.randomDouble(),
+    confidence: Double = ESTestCase.randomDouble()
+): String {
+    return """{
+          "detector_id" : "$detectorId",
+          "data_start_time" : $dataStartTime,
+          "data_end_time" : $dataEndTime,
+          "feature_data" : [
+            {
+              "feature_id" : "$featureId",
+              "feature_name" : "$featureName",
+              "data" : $featureData
+            }
+          ],
+          "execution_start_time" : $executionStartTime,
+          "execution_end_time" : $executionEndTime,
+          "anomaly_score" : $anomalyScore,
+          "anomaly_grade" : $anomalyGrade,
+          "confidence" : $confidence
+        }
+        """.trimIndent()
+}
+
+fun maxAnomalyGradeSearchInput(
+    adResultIndex: String = ".opendistro-anomaly-results-history",
+    detectorId: String = ESTestCase.randomAlphaOfLength(10),
+    size: Int = 1
+): SearchInput {
+    val rangeQuery = QueryBuilders.rangeQuery("execution_end_time")
+            .gt("{{period_end}}||-10d")
+            .lte("{{period_end}}")
+            .format("epoch_millis")
+    val termQuery = QueryBuilders.termQuery("detector_id", detectorId)
+
+    var boolQueryBuilder = BoolQueryBuilder()
+    boolQueryBuilder.filter(rangeQuery).filter(termQuery)
+
+    val aggregationBuilder = AggregationBuilders.max("max_anomaly_grade").field("anomaly_grade")
+    val searchSourceBuilder = SearchSourceBuilder().query(boolQueryBuilder).aggregation(aggregationBuilder).size(size)
+    return SearchInput(indices = listOf(adResultIndex), query = searchSourceBuilder)
+}
+
+fun adMonitorTrigger(): Trigger {
+    val triggerScript = """
+            return ctx.results[0].aggregations.max_anomaly_grade.value != null && 
+                   ctx.results[0].aggregations.max_anomaly_grade.value > 0.7
+        """.trimIndent()
+    return randomTrigger(condition = Script(triggerScript))
+}
+
+fun adSearchInput(detectorId: String): SearchInput {
+    return maxAnomalyGradeSearchInput(adResultIndex = ANOMALY_RESULT_INDEX, detectorId = detectorId, size = 10)
+}
+
+fun randomADMonitor(
+    name: String = ESRestTestCase.randomAlphaOfLength(10),
+    user: User? = randomUser(),
+    inputs: List<Input> = listOf(adSearchInput("test_detector_id")),
+    schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
+    enabled: Boolean = ESTestCase.randomBoolean(),
+    triggers: List<Trigger> = (1..ESTestCase.randomInt(10)).map { randomTrigger() },
+    enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
+    lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+    withMetadata: Boolean = false
+): Monitor {
+    return Monitor(name = name, enabled = enabled, inputs = inputs, schedule = schedule, triggers = triggers,
+            enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
+            user = user, uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
+}
+
+fun randomADUser(backendRole: String = ESRestTestCase.randomAlphaOfLength(10)): User {
+    return User(ESRestTestCase.randomAlphaOfLength(10), listOf(backendRole),
+            listOf(ESRestTestCase.randomAlphaOfLength(10), "all_access"), listOf("test_attr=test"))
+}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -461,6 +461,11 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         return index
     }
 
+    protected fun createTestIndex(index: String, mapping: String): String {
+        createIndex(index, Settings.EMPTY, mapping.trimIndent())
+        return index
+    }
+
     protected fun createTestConfigIndex(index: String = "." + randomAlphaOfLength(10).toLowerCase(Locale.ROOT)): String {
         try {
             createIndex(index, Settings.builder().build(), """

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -15,8 +15,10 @@
 package com.amazon.opendistroforelasticsearch.alerting.resthandler
 
 import com.amazon.opendistroforelasticsearch.alerting.ALERTING_BASE_URI
+import com.amazon.opendistroforelasticsearch.alerting.ANOMALY_DETECTOR_INDEX
 import com.amazon.opendistroforelasticsearch.alerting.AlertingRestTestCase
 import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertIndices
+import com.amazon.opendistroforelasticsearch.alerting.anomalyDetectorIndexMapping
 import com.amazon.opendistroforelasticsearch.alerting.core.model.CronSchedule
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
@@ -25,8 +27,12 @@ import com.amazon.opendistroforelasticsearch.alerting.makeRequest
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.alerting.randomADMonitor
+import com.amazon.opendistroforelasticsearch.alerting.randomADUser
 import com.amazon.opendistroforelasticsearch.alerting.randomAction
 import com.amazon.opendistroforelasticsearch.alerting.randomAlert
+import com.amazon.opendistroforelasticsearch.alerting.randomAnomalyDetector
+import com.amazon.opendistroforelasticsearch.alerting.randomAnomalyDetectorWithUser
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
 import com.amazon.opendistroforelasticsearch.alerting.randomThrottle
 import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
@@ -36,6 +42,7 @@ import org.apache.http.entity.ContentType
 import org.apache.http.message.BasicHeader
 import org.apache.http.nio.entity.NStringEntity
 import org.elasticsearch.client.ResponseException
+import org.elasticsearch.client.WarningFailureException
 import org.elasticsearch.common.bytes.BytesReference
 import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.common.xcontent.ToXContent
@@ -154,6 +161,75 @@ class MonitorRestApiIT : AlertingRestTestCase() {
             // Without security plugin we get BAD_REQUEST correctly. With security_plugin we get INTERNAL_SERVER_ERROR, till above issue is fixed.
             assertTrue("Unexpected status",
                     listOf<RestStatus>(RestStatus.BAD_REQUEST, RestStatus.FORBIDDEN).contains(e.response.restStatus()))
+        }
+    }
+
+    fun `test creating an AD monitor without detector index`() {
+        try {
+            val monitor = randomADMonitor()
+
+            client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+        } catch (e: ResponseException) {
+            // When user create AD monitor without detector index, will throw index not found exception
+            assertTrue("Unexpected error", e.message!!.contains("Configured indices are not found"))
+            assertTrue("Unexpected status",
+                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+        }
+    }
+
+    fun `test creating an AD monitor with detector index created but no detectors`() {
+        createAnomalyDetectorIndex()
+        try {
+            val monitor = randomADMonitor()
+            client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+        } catch (e: ResponseException) {
+            // When user create AD monitor with no detector, will throw exception
+            assertTrue("Unexpected error", e.message!!.contains("User has no available detectors"))
+            assertTrue("Unexpected status",
+                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+        }
+    }
+
+    fun `test creating an AD monitor with no detector has monitor backend role`() {
+        createAnomalyDetectorIndex()
+        indexDoc(ANOMALY_DETECTOR_INDEX, "1", randomAnomalyDetector())
+        indexDoc(ANOMALY_DETECTOR_INDEX, "2", randomAnomalyDetectorWithUser(randomAlphaOfLength(5)))
+        try {
+            val monitor = randomADMonitor()
+            client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+        } catch (e: ResponseException) {
+            // When user create AD monitor with no detector has backend role, will throw exception
+            assertTrue("Unexpected error", e.message!!.contains("User has no available detectors"))
+            assertTrue("Unexpected status",
+                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+        }
+    }
+
+    fun `test creating an AD monitor with detector has monitor backend role`() {
+        createAnomalyDetectorIndex()
+        val backendRole = "test-role"
+        val user = randomADUser(backendRole)
+        indexDoc(ANOMALY_DETECTOR_INDEX, "1", randomAnomalyDetector())
+        indexDoc(ANOMALY_DETECTOR_INDEX, "2", randomAnomalyDetectorWithUser(randomAlphaOfLength(5)))
+        indexDoc(ANOMALY_DETECTOR_INDEX, "3", randomAnomalyDetectorWithUser(backendRole = backendRole), refresh = true)
+
+        val monitor = randomADMonitor(user = user)
+        val createResponse = client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+        assertEquals("Create monitor failed", RestStatus.CREATED, createResponse.restStatus())
+        val responseBody = createResponse.asMap()
+        val createdId = responseBody["_id"] as String
+        val createdVersion = responseBody["_version"] as Int
+        assertNotEquals("response is missing Id", Monitor.NO_ID, createdId)
+        assertTrue("incorrect version", createdVersion > 0)
+        assertEquals("Incorrect Location header", "$ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
+    }
+
+    private fun createAnomalyDetectorIndex() {
+        try {
+            createTestIndex(ANOMALY_DETECTOR_INDEX, anomalyDetectorIndexMapping())
+        } catch (e: Exception) {
+            // WarningFailureException is expected as we are creating system index start with dot
+            assertTrue(e is WarningFailureException)
         }
     }
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -104,7 +104,6 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         assertEquals("Incorrect Location header", "$ALERTING_BASE_URI/$createdId", createResponse.getHeader("Location"))
     }
 
-    @Throws(Exception::class)
     fun `test creating a monitor with action threshold greater than max threshold`() {
         val monitor = randomMonitorWithThrottle(100000, ChronoUnit.MINUTES)
 
@@ -115,7 +114,6 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    @Throws(Exception::class)
     fun `test creating a monitor with action threshold less than min threshold`() {
         val monitor = randomMonitorWithThrottle(-1)
 
@@ -126,7 +124,6 @@ class MonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    @Throws(Exception::class)
     fun `test creating a monitor with updating action threshold`() {
         adminClient().updateSettings("opendistro.alerting.action_throttle_max_value", TimeValue.timeValueHours(1))
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtilsTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtilsTests.kt
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.util
+
+import com.amazon.opendistroforelasticsearch.alerting.ANOMALY_RESULT_INDEX
+import com.amazon.opendistroforelasticsearch.alerting.core.model.Input
+import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
+import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
+import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.index.query.QueryBuilders
+import org.elasticsearch.search.builder.SearchSourceBuilder
+import org.elasticsearch.test.ESTestCase
+
+class AnomalyDetectionUtilsTests : ESTestCase() {
+
+    fun `test is ad monitor`() {
+        val monitor = randomMonitor(
+                inputs = listOf(SearchInput(listOf(ANOMALY_RESULT_INDEX),
+                        SearchSourceBuilder().query(QueryBuilders.matchAllQuery())))
+        )
+        assertTrue(isADMonitor(monitor))
+    }
+
+    fun `test not ad monitor if monitor have no inputs`() {
+
+        val monitor = randomMonitor(
+                inputs = listOf()
+        )
+        assertFalse(isADMonitor(monitor))
+    }
+
+    fun `test not ad monitor if monitor input is not search input`() {
+        val monitor = randomMonitor(
+                inputs = listOf(object : Input {
+                    override fun name(): String {
+                        TODO("Not yet implemented")
+                    }
+
+                    override fun writeTo(out: StreamOutput?) {
+                        TODO("Not yet implemented")
+                    }
+
+                    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+                        TODO("Not yet implemented")
+                    }
+                })
+        )
+        assertFalse(isADMonitor(monitor))
+    }
+
+    fun `test not ad monitor if monitor input has more than 1 indices`() {
+        val monitor = randomMonitor(
+                inputs = listOf(SearchInput(listOf(randomAlphaOfLength(5), randomAlphaOfLength(5)),
+                        SearchSourceBuilder().query(QueryBuilders.matchAllQuery())))
+        )
+        assertFalse(isADMonitor(monitor))
+    }
+
+    fun `test not ad monitor if monitor input's index name is not AD result index`() {
+        val monitor = randomMonitor(
+                inputs = listOf(SearchInput(listOf(randomAlphaOfLength(5)), SearchSourceBuilder().query(QueryBuilders.matchAllQuery())))
+        )
+        assertFalse(isADMonitor(monitor))
+    }
+
+    fun `test add user role filter with null user`() {
+        val searchSourceBuilder = SearchSourceBuilder()
+        addUserBackendRolesFilter(null, searchSourceBuilder)
+        assertEquals("{\"query\":{\"bool\":{\"must_not\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}}," +
+                "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true," +
+                "\"boost\":1.0}}}", searchSourceBuilder.toString())
+    }
+
+    fun `test add user role filter with null user backend role`() {
+        val searchSourceBuilder = SearchSourceBuilder()
+        addUserBackendRolesFilter(User(randomAlphaOfLength(5), null, listOf(randomAlphaOfLength(5)),
+                listOf(randomAlphaOfLength(5))), searchSourceBuilder)
+        assertEquals("{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}}," +
+                "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"must_not\":[{\"nested\":" +
+                "{\"query\":{\"exists\":{\"field\":\"user.backend_roles.keyword\",\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\"" +
+                ":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true,\"boost\":1.0}}}",
+                searchSourceBuilder.toString())
+    }
+
+    fun `test add user role filter with empty user backend role`() {
+        val searchSourceBuilder = SearchSourceBuilder()
+        addUserBackendRolesFilter(User(randomAlphaOfLength(5), listOf(), listOf(randomAlphaOfLength(5)),
+                listOf(randomAlphaOfLength(5))), searchSourceBuilder)
+        assertEquals("{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}}," +
+                "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"must_not\":[{\"nested\":" +
+                "{\"query\":{\"exists\":{\"field\":\"user.backend_roles.keyword\",\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\"" +
+                ":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true,\"boost\":1.0}}}",
+                searchSourceBuilder.toString())
+    }
+
+    fun `test add user role filter with normal user backend role`() {
+        val searchSourceBuilder = SearchSourceBuilder()
+        val backendRole1 = randomAlphaOfLength(5)
+        val backendRole2 = randomAlphaOfLength(5)
+        addUserBackendRolesFilter(User(randomAlphaOfLength(5), listOf(backendRole1, backendRole2), listOf(randomAlphaOfLength(5)),
+                listOf(randomAlphaOfLength(5))), searchSourceBuilder)
+        assertEquals("{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"terms\":{\"user.backend_roles.keyword\":" +
+                "[\"$backendRole1\",\"$backendRole2\"]," +
+                "\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}]," +
+                "\"adjust_pure_negative\":true,\"boost\":1.0}}}", searchSourceBuilder.toString())
+    }
+}

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
@@ -145,11 +145,14 @@ fun XContentBuilder.optionalUserField(name: String, user: User?): XContentBuilde
 }
 
 fun addFilter(user: User, searchSourceBuilder: SearchSourceBuilder, fieldName: String) {
-    val filterBckendRoles = QueryBuilders.termsQuery(fieldName, user.backendRoles)
-    val queryBuilder = searchSourceBuilder.query() as BoolQueryBuilder
-    searchSourceBuilder.query(queryBuilder.filter(filterBckendRoles))
+    addUserRolesFilter(user.backendRoles, searchSourceBuilder, fieldName)
 }
 
+fun addUserRolesFilter(userRoles: List<String>, searchSourceBuilder: SearchSourceBuilder, fieldName: String) {
+    val filterBackendRoles = QueryBuilders.termsQuery(fieldName, userRoles)
+    val queryBuilder = searchSourceBuilder.query() as BoolQueryBuilder
+    searchSourceBuilder.query(queryBuilder.filter(filterBackendRoles))
+}
 /**
  * Extension function for ES 6.3 and above that duplicates the ES 6.2 XContentBuilder.string() method.
  */

--- a/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
+++ b/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt
@@ -145,14 +145,11 @@ fun XContentBuilder.optionalUserField(name: String, user: User?): XContentBuilde
 }
 
 fun addFilter(user: User, searchSourceBuilder: SearchSourceBuilder, fieldName: String) {
-    addUserRolesFilter(user.backendRoles, searchSourceBuilder, fieldName)
-}
-
-fun addUserRolesFilter(userRoles: List<String>, searchSourceBuilder: SearchSourceBuilder, fieldName: String) {
-    val filterBackendRoles = QueryBuilders.termsQuery(fieldName, userRoles)
+    val filterBackendRoles = QueryBuilders.termsQuery(fieldName, user.backendRoles)
     val queryBuilder = searchSourceBuilder.query() as BoolQueryBuilder
     searchSourceBuilder.query(queryBuilder.filter(filterBackendRoles))
 }
+
 /**
  * Extension function for ES 6.3 and above that duplicates the ES 6.2 XContentBuilder.string() method.
  */


### PR DESCRIPTION
*Issue #https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/195*

## Description of changes:

AD result index will be system indices, so create AD monitor will fail as common users have no read permission on anomaly result index.

And AD and Alerting will provide document level access control with user backend role user. This PR adds detector backend role checking when create and run monitor.

**Backend role checking logic for AD monitor creation:**
1.If monitor's user is null, then check if there is detector with null user. For old monitor and detector, they have no user field. With this we can provide backward compatibility. 
2.If monitor's user is not null, but has no backend roles, then will check if there is detector with empty backend role. 
3.If monitor's user has backend roles, will check if there is detector which backend role has any of the monitor's user backend roles.

The same logic for AD monitor's schedule job run, just change detector existence checking to user role filter query.

**Tradeoff**
We have no way to verify if user has AD read permission in alerting plugin now. So we have to check user's backend role no matter the backend role filter open or not. If we don't add backend role checking when the filter setting disabled, that will be a security leak: if user has permission to create monitor, they can get any detector's results even they have no AD read permission. We make a balance on security and user experience and choose to prioritize security.  In next phase, when secure rest client ready or security plugin provides permission check action, we will add AD read permission check and provide complete user experience.

## Test
Add UT and IT cases for AD monitor creation and run.
Have tested by running `./gradlew :alerting:run`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
