### PR TITLE
Fix parsing User info when User is null

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
@@ -182,7 +182,7 @@ data class Alert(
                     SCHEMA_VERSION_FIELD -> schemaVersion = xcp.intValue()
                     MONITOR_NAME_FIELD -> monitorName = xcp.text()
                     MONITOR_VERSION_FIELD -> monitorVersion = xcp.longValue()
-                    MONITOR_USER_FIELD -> monitorUser = User.parse(xcp)
+                    MONITOR_USER_FIELD -> monitorUser = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else User.parse(xcp)
                     TRIGGER_ID_FIELD -> triggerId = xcp.text()
                     STATE_FIELD -> state = State.valueOf(xcp.text())
                     TRIGGER_NAME_FIELD -> triggerName = xcp.text()

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Monitor.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Monitor.kt
@@ -191,7 +191,7 @@ data class Monitor(
                 when (fieldName) {
                     SCHEMA_VERSION_FIELD -> schemaVersion = xcp.intValue()
                     NAME_FIELD -> name = xcp.text()
-                    USER_FIELD -> user = User.parse(xcp)
+                    USER_FIELD -> user = if (xcp.currentToken() == Token.VALUE_NULL) null else User.parse(xcp)
                     ENABLED_FIELD -> enabled = xcp.booleanValue()
                     SCHEDULE_FIELD -> schedule = Schedule.parse(xcp)
                     INPUTS_FIELD -> {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/destination/Destination.kt
@@ -154,7 +154,7 @@ data class Destination(
 
                 when (fieldName) {
                     NAME_FIELD -> name = xcp.text()
-                    USER_FIELD -> user = User.parse(xcp)
+                    USER_FIELD -> user = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else User.parse(xcp)
                     TYPE_FIELD -> {
                         type = xcp.text()
                         val allowedTypes = DestinationType.values().map { it.value }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/DestinationTests.kt
@@ -303,4 +303,11 @@ class DestinationTests : ESTestCase() {
         val parsedDest = Destination.parse(parser(userString))
         assertNotNull(parsedDest.user)
     }
+
+    fun `test chime destination with user as null`() {
+        val userString = "{\"type\":\"chime\",\"name\":\"TestChimeDest\",\"user\":null,\"schema_version\":1," +
+            "\"last_update_time\":1600063313658,\"chime\":{\"url\":\"test.com\"}}"
+        val parsedDest = Destination.parse(parser(userString))
+        assertNull(parsedDest.user)
+    }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/XContentTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/XContentTests.kt
@@ -28,6 +28,7 @@ import com.amazon.opendistroforelasticsearch.alerting.randomAlert
 import com.amazon.opendistroforelasticsearch.alerting.randomEmailAccount
 import com.amazon.opendistroforelasticsearch.alerting.randomEmailGroup
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
+import com.amazon.opendistroforelasticsearch.alerting.randomMonitorWithoutUser
 import com.amazon.opendistroforelasticsearch.alerting.randomThrottle
 import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
 import com.amazon.opendistroforelasticsearch.alerting.randomUser
@@ -127,6 +128,17 @@ class XContentTests : ESTestCase() {
         assertNull(parsedAlert.monitorUser)
     }
 
+    fun `test alert parsing with user as null`() {
+        val alertStr = "{\"id\":\"\",\"version\":-1,\"monitor_id\":\"\",\"schema_version\":0,\"monitor_version\":1,\"monitor_user\":null," +
+            "\"monitor_name\":\"ARahqfRaJG\",\"trigger_id\":\"fhe1-XQBySl0wQKDBkOG\",\"trigger_name\":\"ffELMuhlro\"," +
+            "\"state\":\"ACTIVE\",\"error_message\":null,\"alert_history\":[],\"severity\":\"1\",\"action_execution_results\"" +
+            ":[{\"action_id\":\"ghe1-XQBySl0wQKDBkOG\",\"last_execution_time\":1601917224583,\"throttled_count\":-1478015168}," +
+            "{\"action_id\":\"gxe1-XQBySl0wQKDBkOH\",\"last_execution_time\":1601917224583,\"throttled_count\":-768533744}]," +
+            "\"start_time\":1601917224599,\"last_notification_time\":null,\"end_time\":null,\"acknowledged_time\":null}"
+        val parsedAlert = Alert.parse(parser(alertStr))
+        assertNull(parsedAlert.monitorUser)
+    }
+
     fun `test action execution result parsing`() {
         val actionExecutionResult = randomActionExecutionResult()
 
@@ -163,10 +175,11 @@ class XContentTests : ESTestCase() {
     }
 
     fun `test monitor parsing without user`() {
-        val prevVersionMonitorStr = "{\"type\":\"monitor\",\"schema_version\":0,\"name\":\"bkHIMJSbfj\",\"enabled\":true,\"enabled_time" +
-                "\":1600052622174,\"schedule\":{\"period\":{\"interval\":5,\"unit\":\"MINUTES\"}},\"inputs\":[{\"search\":{\"indices\"" +
-                ":[],\"query\":{\"query\":{\"match_all\":{\"boost\":1.0}}}}}],\"triggers\":[],\"last_update_time\":1600052622174}"
-        val parsedMonitor = Monitor.parse(parser(prevVersionMonitorStr))
+        val monitor = randomMonitorWithoutUser()
+
+        val monitorString = monitor.toJsonString()
+        val parsedMonitor = Monitor.parse(parser(monitorString))
+        assertEquals("Round tripping Monitor doesn't work", monitor, parsedMonitor)
         assertNull(parsedMonitor.user)
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set User to null when parsing null User data from Monitor, Destination, or Alert object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
