### PR TITLE
Resolve user, backendroles, roles from threadcontext instead of /authinfo rest call

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -18,14 +18,14 @@ import com.amazon.opendistroforelasticsearch.alerting.action.AcknowledgeAlertAct
 import com.amazon.opendistroforelasticsearch.alerting.action.DeleteDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.action.DeleteEmailAccountAction
 import com.amazon.opendistroforelasticsearch.alerting.action.DeleteEmailGroupAction
-import com.amazon.opendistroforelasticsearch.alerting.action.IndexDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.action.DeleteMonitorAction
 import com.amazon.opendistroforelasticsearch.alerting.action.ExecuteMonitorAction
-import com.amazon.opendistroforelasticsearch.alerting.action.GetEmailAccountAction
-import com.amazon.opendistroforelasticsearch.alerting.action.GetEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.action.GetAlertsAction
 import com.amazon.opendistroforelasticsearch.alerting.action.GetDestinationsAction
+import com.amazon.opendistroforelasticsearch.alerting.action.GetEmailAccountAction
+import com.amazon.opendistroforelasticsearch.alerting.action.GetEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.action.GetMonitorAction
+import com.amazon.opendistroforelasticsearch.alerting.action.IndexDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.action.IndexEmailAccountAction
 import com.amazon.opendistroforelasticsearch.alerting.action.IndexEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.action.IndexMonitorAction
@@ -49,10 +49,10 @@ import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestDeleteEmai
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestDeleteEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestDeleteMonitorAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestExecuteMonitorAction
-import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetEmailAccountAction
-import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetAlertsAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetDestinationsAction
+import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetEmailAccountAction
+import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestGetMonitorAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestIndexDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestIndexEmailAccountAction
@@ -68,25 +68,23 @@ import com.amazon.opendistroforelasticsearch.alerting.transport.TransportAcknowl
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportDeleteDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportDeleteEmailAccountAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportDeleteEmailGroupAction
-import com.amazon.opendistroforelasticsearch.alerting.transport.TransportIndexDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportDeleteMonitorAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportExecuteMonitorAction
+import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetAlertsAction
+import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetDestinationsAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetEmailAccountAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetEmailGroupAction
-import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetAlertsAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetMonitorAction
+import com.amazon.opendistroforelasticsearch.alerting.transport.TransportIndexDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportIndexEmailAccountAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportIndexEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportIndexMonitorAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportSearchEmailAccountAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportSearchEmailGroupAction
 import com.amazon.opendistroforelasticsearch.alerting.transport.TransportSearchMonitorAction
-import com.amazon.opendistroforelasticsearch.commons.rest.SecureRestClientBuilder
-import com.amazon.opendistroforelasticsearch.alerting.transport.TransportGetDestinationsAction
 import org.elasticsearch.action.ActionRequest
 import org.elasticsearch.action.ActionResponse
 import org.elasticsearch.client.Client
-import org.elasticsearch.client.RestClient
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver
 import org.elasticsearch.cluster.node.DiscoveryNodes
 import org.elasticsearch.cluster.service.ClusterService
@@ -145,7 +143,6 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     lateinit var threadPool: ThreadPool
     lateinit var alertIndices: AlertIndices
     lateinit var clusterService: ClusterService
-    lateinit var restClient: RestClient
 
     override fun getRestHandlers(
         settings: Settings,
@@ -159,7 +156,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         return listOf(RestGetMonitorAction(),
                 RestDeleteMonitorAction(),
                 RestIndexMonitorAction(),
-                RestSearchMonitorAction(settings, clusterService, restClient),
+                RestSearchMonitorAction(settings, clusterService),
                 RestExecuteMonitorAction(),
                 RestAcknowledgeAlertAction(),
                 RestScheduledJobStatsHandler("_alerting"),
@@ -228,8 +225,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
         sweeper = JobSweeper(environment.settings(), client, clusterService, threadPool, xContentRegistry, scheduler, ALERTING_JOB_TYPES)
         this.threadPool = threadPool
         this.clusterService = clusterService
-        this.restClient = SecureRestClientBuilder(settings, environment.configFile()).build()
-        return listOf(sweeper, scheduler, runner, scheduledJobIndices, restClient)
+        return listOf(sweeper, scheduler, runner, scheduledJobIndices)
     }
 
     override fun getSettings(): List<Setting<*>> {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetAlertsRequest.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetAlertsRequest.kt
@@ -27,20 +27,17 @@ class GetAlertsRequest : ActionRequest {
     val severityLevel: String
     val alertState: String
     val monitorId: String?
-    val authHeader: String?
 
     constructor(
         table: Table,
         severityLevel: String,
         alertState: String,
-        monitorId: String?,
-        authHeader: String?
+        monitorId: String?
     ) : super() {
         this.table = table
         this.severityLevel = severityLevel
         this.alertState = alertState
         this.monitorId = monitorId
-        this.authHeader = authHeader
     }
 
     @Throws(IOException::class)
@@ -48,8 +45,7 @@ class GetAlertsRequest : ActionRequest {
         table = Table.readFrom(sin),
         severityLevel = sin.readString(),
         alertState = sin.readString(),
-        monitorId = sin.readOptionalString(),
-        authHeader = sin.readOptionalString()
+        monitorId = sin.readOptionalString()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -62,6 +58,5 @@ class GetAlertsRequest : ActionRequest {
         out.writeString(severityLevel)
         out.writeString(alertState)
         out.writeOptionalString(monitorId)
-        out.writeOptionalString(authHeader)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetDestinationsRequest.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetDestinationsRequest.kt
@@ -29,22 +29,19 @@ class GetDestinationsRequest : ActionRequest {
     val srcContext: FetchSourceContext?
     val table: Table
     val destinationType: String
-    val authHeader: String?
 
     constructor(
         destinationId: String?,
         version: Long,
         srcContext: FetchSourceContext?,
         table: Table,
-        destinationType: String,
-        authHeader: String?
+        destinationType: String
     ) : super() {
         this.destinationId = destinationId
         this.version = version
         this.srcContext = srcContext
         this.table = table
         this.destinationType = destinationType
-        this.authHeader = authHeader
     }
 
     @Throws(IOException::class)
@@ -55,8 +52,7 @@ class GetDestinationsRequest : ActionRequest {
             FetchSourceContext(sin)
         } else null,
         table = Table.readFrom(sin),
-        destinationType = sin.readString(),
-        authHeader = sin.readOptionalString()
+        destinationType = sin.readString()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -71,6 +67,5 @@ class GetDestinationsRequest : ActionRequest {
         srcContext?.writeTo(out)
         table.writeTo(out)
         out.writeString(destinationType)
-        out.writeOptionalString(authHeader)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequest.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequest.kt
@@ -30,7 +30,6 @@ class IndexDestinationRequest : ActionRequest {
     val primaryTerm: Long
     val refreshPolicy: WriteRequest.RefreshPolicy
     val method: RestRequest.Method
-    val authHeader: String?
     var destination: Destination
 
     constructor(
@@ -39,7 +38,6 @@ class IndexDestinationRequest : ActionRequest {
         primaryTerm: Long,
         refreshPolicy: WriteRequest.RefreshPolicy,
         method: RestRequest.Method,
-        authHeader: String?,
         destination: Destination
     ): super() {
         this.destinationId = destinationId
@@ -47,7 +45,6 @@ class IndexDestinationRequest : ActionRequest {
         this.primaryTerm = primaryTerm
         this.refreshPolicy = refreshPolicy
         this.method = method
-        this.authHeader = authHeader
         this.destination = destination
     }
 
@@ -58,7 +55,6 @@ class IndexDestinationRequest : ActionRequest {
         this.primaryTerm = sin.readLong()
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(sin)
         this.method = sin.readEnum(RestRequest.Method::class.java)
-        this.authHeader = sin.readOptionalString()
         this.destination = Destination.readFrom(sin)
     }
 
@@ -73,7 +69,6 @@ class IndexDestinationRequest : ActionRequest {
         out.writeLong(primaryTerm)
         refreshPolicy.writeTo(out)
         out.writeEnum(method)
-        out.writeOptionalString(authHeader)
         destination.writeTo(out)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorRequest.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorRequest.kt
@@ -30,7 +30,6 @@ class IndexMonitorRequest : ActionRequest {
     val primaryTerm: Long
     val refreshPolicy: WriteRequest.RefreshPolicy
     val method: RestRequest.Method
-    val authHeader: String?
     var monitor: Monitor
 
     constructor(
@@ -39,7 +38,6 @@ class IndexMonitorRequest : ActionRequest {
         primaryTerm: Long,
         refreshPolicy: WriteRequest.RefreshPolicy,
         method: RestRequest.Method,
-        authHeader: String?,
         monitor: Monitor
     ): super() {
         this.monitorId = monitorId
@@ -47,7 +45,6 @@ class IndexMonitorRequest : ActionRequest {
         this.primaryTerm = primaryTerm
         this.refreshPolicy = refreshPolicy
         this.method = method
-        this.authHeader = authHeader
         this.monitor = monitor
     }
 
@@ -58,7 +55,6 @@ class IndexMonitorRequest : ActionRequest {
         primaryTerm = sin.readLong(),
         refreshPolicy = WriteRequest.RefreshPolicy.readFrom(sin),
         method = sin.readEnum(RestRequest.Method::class.java),
-        authHeader = sin.readOptionalString(),
         monitor = Monitor.readFrom(sin) as Monitor
     )
 
@@ -73,7 +69,6 @@ class IndexMonitorRequest : ActionRequest {
         out.writeLong(primaryTerm)
         refreshPolicy.writeTo(out)
         out.writeEnum(method)
-        out.writeOptionalString(authHeader)
         monitor.writeTo(out)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/SearchMonitorRequest.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/SearchMonitorRequest.kt
@@ -25,20 +25,16 @@ import java.io.IOException
 class SearchMonitorRequest : ActionRequest {
 
     val searchRequest: SearchRequest
-    val authHeader: String?
 
     constructor(
-        searchRequest: SearchRequest,
-        authHeader: String?
+        searchRequest: SearchRequest
     ): super() {
         this.searchRequest = searchRequest
-        this.authHeader = authHeader
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput): this(
-            searchRequest = SearchRequest(sin),
-            authHeader = sin.readOptionalString()
+        searchRequest = SearchRequest(sin)
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -48,6 +44,5 @@ class SearchMonitorRequest : ActionRequest {
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         searchRequest.writeTo(out)
-        out.writeOptionalString(authHeader)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -19,7 +19,6 @@ import com.amazon.opendistroforelasticsearch.alerting.AlertingPlugin
 import com.amazon.opendistroforelasticsearch.alerting.action.GetAlertsAction
 import com.amazon.opendistroforelasticsearch.alerting.action.GetAlertsRequest
 import com.amazon.opendistroforelasticsearch.alerting.model.Table
-import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.rest.BaseRestHandler

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetAlertsAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetAlertsAction.kt
@@ -58,7 +58,6 @@ class RestGetAlertsAction : BaseRestHandler() {
         val severityLevel = request.param("severityLevel", "ALL")
         val alertState = request.param("alertState", "ALL")
         val monitorId: String? = request.param("monitorId")
-        val auth = request.header(ConfigConstants.AUTHORIZATION)
         val table = Table(
                 sortOrder,
                 sortString,
@@ -68,7 +67,7 @@ class RestGetAlertsAction : BaseRestHandler() {
                 searchString
         )
 
-        val getAlertsRequest = GetAlertsRequest(table, severityLevel, alertState, monitorId, auth)
+        val getAlertsRequest = GetAlertsRequest(table, severityLevel, alertState, monitorId)
         return RestChannelConsumer {
             channel -> client.execute(GetAlertsAction.INSTANCE, getAlertsRequest, RestToXContentListener(channel))
         }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -67,7 +67,6 @@ class RestGetDestinationsAction : BaseRestHandler() {
         val startIndex = request.paramAsInt("startIndex", 0)
         val searchString = request.param("searchString", "")
         val destinationType = request.param("destinationType", "ALL")
-        val auth = request.header(ConfigConstants.AUTHORIZATION)
 
         val table = Table(
                 sortOrder,
@@ -83,8 +82,7 @@ class RestGetDestinationsAction : BaseRestHandler() {
                 RestActions.parseVersion(request),
                 srcContext,
                 table,
-                destinationType,
-                auth
+                destinationType
         )
         return RestChannelConsumer {
             channel -> client.execute(GetDestinationsAction.INSTANCE, getDestinationsRequest, RestToXContentListener(channel))

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestGetDestinationsAction.kt
@@ -20,7 +20,6 @@ import com.amazon.opendistroforelasticsearch.alerting.action.GetDestinationsActi
 import com.amazon.opendistroforelasticsearch.alerting.action.GetDestinationsRequest
 import com.amazon.opendistroforelasticsearch.alerting.model.Table
 import com.amazon.opendistroforelasticsearch.alerting.util.context
-import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.rest.BaseRestHandler

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -80,8 +80,7 @@ class RestIndexDestinationAction : BaseRestHandler() {
         } else {
             WriteRequest.RefreshPolicy.IMMEDIATE
         }
-        val auth = request.header(ConfigConstants.AUTHORIZATION)
-        val indexDestinationRequest = IndexDestinationRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), auth, destination)
+        val indexDestinationRequest = IndexDestinationRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), destination)
         return RestChannelConsumer {
             channel -> client.execute(IndexDestinationAction.INSTANCE, indexDestinationRequest,
                 indexDestinationResponse(channel, request.method()))

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexDestinationAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexDestinationAction.kt
@@ -23,7 +23,6 @@ import com.amazon.opendistroforelasticsearch.alerting.model.destination.Destinat
 import com.amazon.opendistroforelasticsearch.alerting.util.IF_PRIMARY_TERM
 import com.amazon.opendistroforelasticsearch.alerting.util.IF_SEQ_NO
 import com.amazon.opendistroforelasticsearch.alerting.util.REFRESH
-import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.support.WriteRequest
 import org.elasticsearch.client.node.NodeClient

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -82,8 +82,7 @@ class RestIndexMonitorAction : BaseRestHandler() {
         } else {
             WriteRequest.RefreshPolicy.IMMEDIATE
         }
-        val auth = request.header(ConfigConstants.AUTHORIZATION)
-        val indexMonitorRequest = IndexMonitorRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), auth, monitor)
+        val indexMonitorRequest = IndexMonitorRequest(id, seqNo, primaryTerm, refreshPolicy, request.method(), monitor)
 
         return RestChannelConsumer { channel ->
             client.execute(IndexMonitorAction.INSTANCE, indexMonitorRequest, indexMonitorResponse(channel, request.method()))

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -22,7 +22,6 @@ import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.util.IF_PRIMARY_TERM
 import com.amazon.opendistroforelasticsearch.alerting.util.IF_SEQ_NO
 import com.amazon.opendistroforelasticsearch.alerting.util.REFRESH
-import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.support.WriteRequest
 import org.elasticsearch.client.node.NodeClient

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -82,7 +82,6 @@ class RestSearchMonitorAction(
         log.debug("${request.method()} ${AlertingPlugin.MONITOR_BASE_URI}/_search")
 
         val index = request.param("index", SCHEDULED_JOBS_INDEX)
-        val auth = request.header(ConfigConstants.AUTHORIZATION)
         val searchSourceBuilder = SearchSourceBuilder()
         searchSourceBuilder.parseXContent(request.contentOrSourceParamParser())
         searchSourceBuilder.fetchSource(context(request))
@@ -96,7 +95,7 @@ class RestSearchMonitorAction(
                 .source(searchSourceBuilder)
                 .indices(index)
 
-        val searchMonitorRequest = SearchMonitorRequest(searchRequest, auth)
+        val searchMonitorRequest = SearchMonitorRequest(searchRequest)
         return RestChannelConsumer { channel ->
             client.execute(SearchMonitorAction.INSTANCE, searchMonitorRequest, searchMonitorResponse(channel))
         }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -25,7 +25,6 @@ import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.search.SearchRequest
 import org.elasticsearch.action.search.SearchResponse
-import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.bytes.BytesReference
@@ -57,8 +56,7 @@ private val log = LogManager.getLogger(RestSearchMonitorAction::class.java)
  */
 class RestSearchMonitorAction(
     val settings: Settings,
-    clusterService: ClusterService,
-    private val restClient: RestClient
+    clusterService: ClusterService
 ) : BaseRestHandler() {
 
     @Volatile private var filterBy = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestSearchMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/RestSearchMonitorAction.kt
@@ -21,7 +21,6 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
 import com.amazon.opendistroforelasticsearch.alerting.util.context
-import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.search.SearchRequest
 import org.elasticsearch.action.search.SearchResponse

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -127,7 +127,7 @@ class TransportGetDestinationsAction @Inject constructor(
         actionListener: ActionListener<GetDestinationsResponse>
     ) {
         if (user == null) {
-            // auth header is null when: 1/ security is disabled. 2/when user is super-admin.
+            // user is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchSourceBuilder, actionListener)
         } else if (!filterByEnabled) {
             // security is enabled and filterby is disabled.

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportGetDestinationsAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportGetDestinationsAction.kt
@@ -23,7 +23,7 @@ import com.amazon.opendistroforelasticsearch.alerting.elasticapi.addFilter
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Destination
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
 import com.amazon.opendistroforelasticsearch.alerting.util.AlertingException
-import com.amazon.opendistroforelasticsearch.commons.authuser.AuthUserRequestBuilder
+import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.ActionListener
@@ -32,9 +32,6 @@ import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.action.support.ActionFilters
 import org.elasticsearch.action.support.HandledTransportAction
 import org.elasticsearch.client.Client
-import org.elasticsearch.client.Response
-import org.elasticsearch.client.ResponseListener
-import org.elasticsearch.client.RestClient
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.Strings
 import org.elasticsearch.common.inject.Inject
@@ -61,7 +58,6 @@ private val log = LogManager.getLogger(TransportGetDestinationsAction::class.jav
 class TransportGetDestinationsAction @Inject constructor(
     transportService: TransportService,
     val client: Client,
-    val restClient: RestClient,
     clusterService: ClusterService,
     actionFilters: ActionFilters,
     val settings: Settings,
@@ -71,6 +67,7 @@ class TransportGetDestinationsAction @Inject constructor(
 ) {
 
     @Volatile private var filterByEnabled = AlertingSettings.FILTER_BY_BACKEND_ROLES.get(settings)
+    private var user: User? = null
 
     init {
         clusterService.clusterSettings.addSettingsUpdateConsumer(AlertingSettings.FILTER_BY_BACKEND_ROLES) { filterByEnabled = it }
@@ -81,6 +78,9 @@ class TransportGetDestinationsAction @Inject constructor(
         getDestinationsRequest: GetDestinationsRequest,
         actionListener: ActionListener<GetDestinationsResponse>
     ) {
+            val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES)
+            log.debug("User and roles string from thread context: $userStr")
+            user = User.parse(userStr)
 
             val tableProp = getDestinationsRequest.table
 
@@ -118,16 +118,15 @@ class TransportGetDestinationsAction @Inject constructor(
             searchSourceBuilder.query(queryBuilder)
 
             client.threadPool().threadContext.stashContext().use {
-                resolve(getDestinationsRequest, searchSourceBuilder, actionListener)
+                resolve(searchSourceBuilder, actionListener)
             }
     }
 
     fun resolve(
-        getDestinationsRequest: GetDestinationsRequest,
         searchSourceBuilder: SearchSourceBuilder,
         actionListener: ActionListener<GetDestinationsResponse>
     ) {
-        if (getDestinationsRequest.authHeader.isNullOrEmpty()) {
+        if (user == null) {
             // auth header is null when: 1/ security is disabled. 2/when user is super-admin.
             search(searchSourceBuilder, actionListener)
         } else if (!filterByEnabled) {
@@ -135,32 +134,13 @@ class TransportGetDestinationsAction @Inject constructor(
             search(searchSourceBuilder, actionListener)
         } else {
             // security is enabled and filterby is enabled.
-            val authRequest = AuthUserRequestBuilder(
-                    getDestinationsRequest.authHeader
-            ).build()
-            restClient.performRequestAsync(authRequest, object : ResponseListener {
-                override fun onSuccess(response: Response) {
-                    try {
-                        val user = User(response)
-                        addFilter(user, searchSourceBuilder, "destination.user.backend_roles")
-                        log.info("Filtering result by: ${user.backendRoles}")
-                        search(searchSourceBuilder, actionListener)
-                    } catch (ex: IOException) {
-                        actionListener.onFailure(AlertingException.wrap(ex))
-                    }
-                }
-
-                override fun onFailure(ex: Exception) {
-                    when (ex.message?.contains("Connection refused")) {
-                        // Connection is refused when security plugin is not present. This case can happen only with integration tests.
-                        true -> {
-                            addFilter(User(), searchSourceBuilder, "destination.user.backend_roles")
-                            search(searchSourceBuilder, actionListener)
-                        }
-                        false -> actionListener.onFailure(AlertingException.wrap(ex))
-                    }
-                }
-            })
+            try {
+                addFilter(user as User, searchSourceBuilder, "destination.user.backend_roles")
+                log.info("Filtering result by: ${user?.backendRoles}")
+                search(searchSourceBuilder, actionListener)
+            } catch (ex: IOException) {
+                actionListener.onFailure(AlertingException.wrap(ex))
+            }
         }
     }
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -33,8 +33,8 @@ import com.amazon.opendistroforelasticsearch.alerting.util.AlertingException
 import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils
 import com.amazon.opendistroforelasticsearch.alerting.util.addUserBackendRolesFilter
 import com.amazon.opendistroforelasticsearch.alerting.util.isADMonitor
+import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import com.amazon.opendistroforelasticsearch.commons.authuser.User
-import com.amazon.opendistroforelasticsearch.commons.authuser.AuthUserRequestBuilder
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.ElasticsearchSecurityException
 import org.elasticsearch.ElasticsearchStatusException
@@ -50,9 +50,6 @@ import org.elasticsearch.action.support.ActionFilters
 import org.elasticsearch.action.support.HandledTransportAction
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.Client
-import org.elasticsearch.client.Response
-import org.elasticsearch.client.ResponseListener
-import org.elasticsearch.client.RestClient
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.inject.Inject
 import org.elasticsearch.common.settings.Settings
@@ -77,7 +74,6 @@ private val log = LogManager.getLogger(TransportIndexMonitorAction::class.java)
 class TransportIndexMonitorAction @Inject constructor(
     transportService: TransportService,
     val client: Client,
-    val restClient: RestClient,
     actionFilters: ActionFilters,
     val scheduledJobIndices: ScheduledJobIndices,
     val clusterService: ClusterService,
@@ -92,7 +88,6 @@ class TransportIndexMonitorAction @Inject constructor(
     @Volatile private var indexTimeout = INDEX_TIMEOUT.get(settings)
     @Volatile private var maxActionThrottle = MAX_ACTION_THROTTLE_VALUE.get(settings)
     @Volatile private var allowList = ALLOW_LIST.get(settings)
-
     var user: User? = null
 
     init {
@@ -105,16 +100,15 @@ class TransportIndexMonitorAction @Inject constructor(
 
     override fun doExecute(task: Task, request: IndexMonitorRequest, actionListener: ActionListener<IndexMonitorResponse>) {
 
-        val usrStr = client.threadPool().threadContext.getTransient<String>("_opendistro_security_user_roles_string")
-
-        log.warn("SRIRAM alerting transport: $usrStr")
-        user = User.parse(usrStr)
+        val userStr = client.threadPool().threadContext.getTransient<String>(ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES)
+        log.debug("User and roles string from thread context: $userStr")
+        user = User.parse(userStr)
 
         if (!isADMonitor(request.monitor)) {
-            checkIndicesAndExecute(client, actionListener, request)
+            checkIndicesAndExecute(client, actionListener, request, user)
         } else {
             // check if user has access to any anomaly detector for AD monitor
-            checkAnomalyDetectorAndExecute(client, actionListener, request)
+            checkAnomalyDetectorAndExecute(client, actionListener, request, user)
         }
     }
 
@@ -125,7 +119,8 @@ class TransportIndexMonitorAction @Inject constructor(
     fun checkIndicesAndExecute(
         client: Client,
         actionListener: ActionListener<IndexMonitorResponse>,
-        request: IndexMonitorRequest
+        request: IndexMonitorRequest,
+        user: User?
     ) {
         val indices = mutableListOf<String>()
         val searchInputs = request.monitor.inputs.filter { it.name() == SearchInput.SEARCH_FIELD }
@@ -139,7 +134,7 @@ class TransportIndexMonitorAction @Inject constructor(
             override fun onResponse(searchResponse: SearchResponse) {
                 // User has read access to configured indices in the monitor, now create monitor with out user context.
                 client.threadPool().threadContext.stashContext().use {
-                    IndexMonitorHandler(client, actionListener, request).resolveUserAndStart()
+                    IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStart()
                 }
             }
 
@@ -167,94 +162,66 @@ class TransportIndexMonitorAction @Inject constructor(
     fun checkAnomalyDetectorAndExecute(
         client: Client,
         actionListener: ActionListener<IndexMonitorResponse>,
-        request: IndexMonitorRequest
+        request: IndexMonitorRequest,
+        user: User?
     ) {
         client.threadPool().threadContext.stashContext().use {
-            IndexMonitorHandler(client, actionListener, request).resolveUserAndStartForAD()
+            IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStartForAD()
         }
     }
 
     inner class IndexMonitorHandler(
         private val client: Client,
         private val actionListener: ActionListener<IndexMonitorResponse>,
-        private val request: IndexMonitorRequest
+        private val request: IndexMonitorRequest,
+        private val user: User?
     ) {
 
         fun resolveUserAndStart() {
-            if (request.authHeader.isNullOrEmpty()) {
+            if (user == null) {
                 // Security is disabled, add empty user to Monitor. user is null for older versions.
                 request.monitor = request.monitor
                         .copy(user = User("", listOf(), listOf(), listOf()))
                 start()
             } else {
-                val authRequest = AuthUserRequestBuilder(request.authHeader).build()
-                restClient.performRequestAsync(authRequest, object : ResponseListener {
-                    override fun onSuccess(response: Response) {
-                        try {
-                            val user = User(response)
-                            request.monitor = request.monitor
-                                    .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttNames))
-                            start()
-                        } catch (ex: IOException) {
-                            actionListener.onFailure(AlertingException.wrap(ex))
-                        }
-                    }
-
-                    override fun onFailure(ex: Exception) {
-                        actionListener.onFailure(AlertingException.wrap(ex))
-                    }
-                })
-                /*if(user != null) {
-                    request.monitor = request.monitor
-                            .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttNames))
-
-                }
-                start()*/
+                request.monitor = request.monitor
+                        .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttNames))
+                start()
             }
         }
 
         fun resolveUserAndStartForAD() {
-            if (request.authHeader.isNullOrEmpty()) {
+            if (user == null) {
                 // Security is disabled, add empty user to Monitor. user is null for older versions.
                 request.monitor = request.monitor
                         .copy(user = User("", listOf(), listOf(), listOf()))
                 start()
             } else {
-                val authRequest = AuthUserRequestBuilder(request.authHeader).build()
-                restClient.performRequestAsync(authRequest, object : ResponseListener {
-                    override fun onSuccess(response: Response) {
-                        try {
-                            val user = User(response)
-                            request.monitor = request.monitor
-                                    .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttNames))
-                            val searchSourceBuilder = SearchSourceBuilder().size(0)
-                            addUserBackendRolesFilter(user, searchSourceBuilder)
-                            val searchRequest = SearchRequest().indices(".opendistro-anomaly-detectors").source(searchSourceBuilder)
-                            client.search(searchRequest, object : ActionListener<SearchResponse> {
-                                override fun onResponse(response: SearchResponse?) {
-                                    val totalHits = response?.hits?.totalHits?.value
-                                    if (totalHits != null && totalHits > 0L) {
-                                        start()
-                                    } else {
-                                        actionListener.onFailure(AlertingException.wrap(
-                                                ElasticsearchStatusException("User has no available detectors", RestStatus.NOT_FOUND)
-                                        ))
-                                    }
-                                }
-
-                                override fun onFailure(t: Exception) {
-                                    actionListener.onFailure(AlertingException.wrap(t))
-                                }
-                            })
-                        } catch (ex: IOException) {
-                            actionListener.onFailure(AlertingException.wrap(ex))
+                try {
+                    request.monitor = request.monitor
+                            .copy(user = User(user.name, user.backendRoles, user.roles, user.customAttNames))
+                    val searchSourceBuilder = SearchSourceBuilder().size(0)
+                    addUserBackendRolesFilter(user, searchSourceBuilder)
+                    val searchRequest = SearchRequest().indices(".opendistro-anomaly-detectors").source(searchSourceBuilder)
+                    client.search(searchRequest, object : ActionListener<SearchResponse> {
+                        override fun onResponse(response: SearchResponse?) {
+                            val totalHits = response?.hits?.totalHits?.value
+                            if (totalHits != null && totalHits > 0L) {
+                                start()
+                            } else {
+                                actionListener.onFailure(AlertingException.wrap(
+                                        ElasticsearchStatusException("User has no available detectors", RestStatus.NOT_FOUND)
+                                ))
+                            }
                         }
-                    }
 
-                    override fun onFailure(ex: Exception) {
-                        actionListener.onFailure(AlertingException.wrap(ex))
-                    }
-                })
+                        override fun onFailure(t: Exception) {
+                            actionListener.onFailure(AlertingException.wrap(t))
+                        }
+                    })
+                } catch (ex: IOException) {
+                    actionListener.onFailure(AlertingException.wrap(ex))
+                }
             }
         }
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -30,7 +30,6 @@ import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.Em
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
 import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings
 import com.amazon.opendistroforelasticsearch.alerting.util.DestinationType
-import com.amazon.opendistroforelasticsearch.commons.ConfigConstants
 import org.apache.http.HttpEntity
 import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType
@@ -55,7 +54,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent
 import org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.search.SearchModule
-import org.elasticsearch.test.rest.ESRestTestCase
 import org.junit.AfterClass
 import org.junit.rules.DisableOnDebug
 import java.net.URLEncoder

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -638,13 +638,6 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
         assertEquals(updateResponse.statusLine.toString(), 200, updateResponse.statusLine.statusCode)
     }
 
-    fun getHeader(): BasicHeader {
-        return when (isHttps()) {
-            false -> BasicHeader("dummy", ESRestTestCase.randomAlphaOfLength(20))
-            true -> BasicHeader(ConfigConstants.AUTHORIZATION, ESRestTestCase.randomAlphaOfLength(20))
-        }
-    }
-
     fun removeEmailFromAllowList() {
         val allowedDestinations = DestinationType.values().toList()
             .filter { destinationType -> destinationType != DestinationType.EMAIL }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetAlertsRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetAlertsRequestTests.kt
@@ -27,7 +27,7 @@ class GetAlertsRequestTests : ESTestCase() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
 
-        val req = GetAlertsRequest(table, "1", "active", null, null)
+        val req = GetAlertsRequest(table, "1", "active", null)
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -44,7 +44,7 @@ class GetAlertsRequestTests : ESTestCase() {
     fun `test get alerts request with filter`() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
-        val req = GetAlertsRequest(table, "1", "active", null, ESRestTestCase.randomAlphaOfLength(20))
+        val req = GetAlertsRequest(table, "1", "active", null)
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -56,13 +56,12 @@ class GetAlertsRequestTests : ESTestCase() {
         assertEquals("active", newReq.alertState)
         assertNull(newReq.monitorId)
         assertEquals(table, newReq.table)
-        assertNotNull(newReq.authHeader)
     }
 
     fun `test validate returns null`() {
         val table = Table("asc", "sortString", null, 1, 0, "")
 
-        val req = GetAlertsRequest(table, "1", "active", null, null)
+        val req = GetAlertsRequest(table, "1", "active", null)
         assertNotNull(req)
         assertNull(req.validate())
     }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetAlertsRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetAlertsRequestTests.kt
@@ -19,7 +19,6 @@ import com.amazon.opendistroforelasticsearch.alerting.model.Table
 import org.elasticsearch.common.io.stream.BytesStreamOutput
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.test.ESTestCase
-import org.elasticsearch.test.rest.ESRestTestCase
 
 class GetAlertsRequestTests : ESTestCase() {
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetDestinationsRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetDestinationsRequestTests.kt
@@ -27,7 +27,7 @@ class GetDestinationsRequestTests : ESTestCase() {
     fun `test get destination request`() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
-        val req = GetDestinationsRequest("1234", 1L, FetchSourceContext.FETCH_SOURCE, table, "slack", null)
+        val req = GetDestinationsRequest("1234", 1L, FetchSourceContext.FETCH_SOURCE, table, "slack")
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -44,7 +44,7 @@ class GetDestinationsRequestTests : ESTestCase() {
     fun `test get destination request without src context`() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
-        val req = GetDestinationsRequest("1234", 1L, null, table, "slack", null)
+        val req = GetDestinationsRequest("1234", 1L, null, table, "slack")
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -61,7 +61,7 @@ class GetDestinationsRequestTests : ESTestCase() {
     fun `test get destination request without destinationId`() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
-        val req = GetDestinationsRequest(null, 1L, FetchSourceContext.FETCH_SOURCE, table, "slack", null)
+        val req = GetDestinationsRequest(null, 1L, FetchSourceContext.FETCH_SOURCE, table, "slack")
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -78,7 +78,7 @@ class GetDestinationsRequestTests : ESTestCase() {
     fun `test get destination request with filter`() {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
-        val req = GetDestinationsRequest(null, 1L, FetchSourceContext.FETCH_SOURCE, table, "slack", ESRestTestCase.randomAlphaOfLength(20))
+        val req = GetDestinationsRequest(null, 1L, FetchSourceContext.FETCH_SOURCE, table, "slack")
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -90,6 +90,5 @@ class GetDestinationsRequestTests : ESTestCase() {
         assertEquals(FetchSourceContext.FETCH_SOURCE, newReq.srcContext)
         assertEquals(table, newReq.table)
         assertEquals("slack", newReq.destinationType)
-        assertNotNull(newReq.authHeader)
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetDestinationsRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetDestinationsRequestTests.kt
@@ -20,7 +20,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext
 import org.elasticsearch.test.ESTestCase
-import org.elasticsearch.test.rest.ESRestTestCase
 
 class GetDestinationsRequestTests : ESTestCase() {
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequestTests.kt
@@ -37,7 +37,6 @@ class IndexDestinationRequestTests : ESTestCase() {
                 1L,
                 WriteRequest.RefreshPolicy.IMMEDIATE,
                 RestRequest.Method.POST,
-                ESRestTestCase.randomAlphaOfLength(20),
                 Destination(
                         "1234",
                         0L,
@@ -77,7 +76,6 @@ class IndexDestinationRequestTests : ESTestCase() {
                 1L,
                 WriteRequest.RefreshPolicy.IMMEDIATE,
                 RestRequest.Method.PUT,
-                ESRestTestCase.randomAlphaOfLength(20),
                 Destination(
                         "1234",
                         0L,

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexDestinationRequestTests.kt
@@ -24,7 +24,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.rest.RestRequest
 import org.elasticsearch.test.ESTestCase
-import org.elasticsearch.test.rest.ESRestTestCase
 import java.time.Instant
 
 class IndexDestinationRequestTests : ESTestCase() {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorRequestTests.kt
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.rest.RestRequest
 import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.elasticsearch.test.ESTestCase
-import org.elasticsearch.test.rest.ESRestTestCase
 
 class IndexMonitorRequestTests : ESTestCase() {
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorRequestTests.kt
@@ -30,7 +30,6 @@ class IndexMonitorRequestTests : ESTestCase() {
     fun `test index monitor post request`() {
 
         val req = IndexMonitorRequest("1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
-                ESRestTestCase.randomAlphaOfLength(20),
                 randomMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder()))))
         assertNotNull(req)
 
@@ -48,7 +47,6 @@ class IndexMonitorRequestTests : ESTestCase() {
     fun `test index monitor put request`() {
 
         val req = IndexMonitorRequest("1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
-                ESRestTestCase.randomAlphaOfLength(20),
                 randomMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder()))))
         assertNotNull(req)
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/SearchMonitorRequestTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/SearchMonitorRequestTests.kt
@@ -29,7 +29,7 @@ class SearchMonitorRequestTests : ESTestCase() {
     fun `test search monitors request`() {
         val searchSourceBuilder = SearchSourceBuilder().from(0).size(100).timeout(TimeValue(60, TimeUnit.SECONDS))
         val searchRequest = SearchRequest().indices(ESRestTestCase.randomAlphaOfLength(10)).source(searchSourceBuilder)
-        val searchMonitorRequest = SearchMonitorRequest(searchRequest, ESRestTestCase.randomAlphaOfLength(20))
+        val searchMonitorRequest = SearchMonitorRequest(searchRequest)
         assertNotNull(searchMonitorRequest)
 
         val out = BytesStreamOutput()
@@ -37,7 +37,6 @@ class SearchMonitorRequestTests : ESTestCase() {
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newReq = SearchMonitorRequest(sin)
 
-        assertNotNull(newReq.authHeader)
         assertNotNull(newReq.searchRequest)
         assertEquals(1, newReq.searchRequest.indices().size)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,11 +25,9 @@ dependencies {
     compile "com.cronutils:cron-utils:7.0.5"
     compile "org.elasticsearch.client:elasticsearch-rest-client:${es_version}"
     compile 'com.google.googlejavaformat:google-java-format:1.3'
-    // compile "com.amazon.opendistroforelasticsearch:common-utils:${opendistroVersion}.1"
+    compile "com.amazon.opendistroforelasticsearch:common-utils:${opendistroVersion}.1"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"
-
-    compile files('/Users/skkosuri/aws-workspace/PluginSecurity/common-utils/build/libs/common-utils-1.11.0.1.jar')
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,9 +25,11 @@ dependencies {
     compile "com.cronutils:cron-utils:7.0.5"
     compile "org.elasticsearch.client:elasticsearch-rest-client:${es_version}"
     compile 'com.google.googlejavaformat:google-java-format:1.3'
-    compile "com.amazon.opendistroforelasticsearch:common-utils:${opendistroVersion}.0"
+    // compile "com.amazon.opendistroforelasticsearch:common-utils:${opendistroVersion}.1"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlin_version}"
+
+    compile files('/Users/skkosuri/aws-workspace/PluginSecurity/common-utils/build/libs/common-utils-1.11.0.1.jar')
 }


### PR DESCRIPTION
*Issue #, if available:*
Resolve user, backendroles, roles from threadcontext instead of /authinfo rest call
*Description of changes:*
Resolve user, backendroles, roles from threadcontext instead of /authinfo rest call

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
