### PR TITLE
Check empty user object for the AD monitor

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtils.kt
@@ -23,6 +23,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder
 import org.elasticsearch.index.query.NestedQueryBuilder
 import org.elasticsearch.index.query.QueryBuilders
 import org.elasticsearch.search.builder.SearchSourceBuilder
+import org.elasticsearch.common.Strings
 
 /**
  * AD monitor is search input monitor on top of anomaly result index. This method will return
@@ -45,8 +46,8 @@ fun addUserBackendRolesFilter(user: User?, searchSourceBuilder: SearchSourceBuil
     var boolQueryBuilder = BoolQueryBuilder()
     val userFieldName = "user"
     val userBackendRoleFieldName = "user.backend_roles.keyword"
-    if (user == null) {
-        // For old monitor and detector, they have no user field
+    if (user == null || Strings.isEmpty(user.name)) {
+        // For 1) old monitor and detector 2) security disabled or superadmin access, they have no/empty user field
         val userRolesFilterQuery = QueryBuilders.existsQuery(userFieldName)
         val nestedQueryBuilder = NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None)
         boolQueryBuilder.mustNot(nestedQueryBuilder)

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtilsTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AnomalyDetectionUtilsTests.kt
@@ -87,6 +87,14 @@ class AnomalyDetectionUtilsTests : ESTestCase() {
                 "\"boost\":1.0}}}", searchSourceBuilder.toString())
     }
 
+    fun `test add user role filter with user with empty name`() {
+        val searchSourceBuilder = SearchSourceBuilder()
+        addUserBackendRolesFilter(User("", mutableListOf<String>(), mutableListOf<String>(), mutableListOf<String>()), searchSourceBuilder)
+        assertEquals("{\"query\":{\"bool\":{\"must_not\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}}," +
+                "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true," +
+                "\"boost\":1.0}}}", searchSourceBuilder.toString())
+    }
+
     fun `test add user role filter with null user backend role`() {
         val searchSourceBuilder = SearchSourceBuilder()
         addUserBackendRolesFilter(User(randomAlphaOfLength(5), null, listOf(randomAlphaOfLength(5)),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When security is disabled, the user in the alerting config index is empty (not null).  This caused AD monitor to add a backend role filter when querying anomaly results.  Since backend roles don't exist when security is disabled, AD monitor gets empty hits and always returns false during trigger evaluation.  The issue basically disables AD monitor for non-fgac domain.

This PR fixes the issue by checking the emptiness of a user: if its name is empty, don't add the backend role filter while querying.

Testing done:
1. added a unit test to verify the backend role filter is not generated when a user is empty.
2. Manually verified AD monitors can find anomalies after the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
