### PR TITLE
Add integ security tests with a limited user

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ When launching a cluster using one of the above commands, logs are placed in `al
 
 1. Setup a local odfe cluster with security plugin.
 
-   - `./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin`
+   - `./gradlew :alerting:integTestRunner -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Dsecurity=true -Duser=admin -Dpassword=admin`
 
-   - `./gradlew :alerting:integTestRunner -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin --tests "com.amazon.opendistroforelasticsearch.alerting.MonitorRunnerIT.test execute monitor returns search result"`
+   - `./gradlew :alerting:integTestRunner -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Dsecurity=true -Duser=admin -Dpassword=admin --tests "com.amazon.opendistroforelasticsearch.alerting.MonitorRunnerIT.test execute monitor returns search result"`
 
 ### Debugging
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -37,6 +37,7 @@ import org.apache.http.entity.ContentType.APPLICATION_JSON
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHeader
 import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.client.Request
 import org.elasticsearch.client.Response
 import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.WarningFailureException
@@ -434,11 +435,19 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     }
 
     protected fun executeMonitor(monitorId: String, params: Map<String, String> = mutableMapOf()): Response {
-        return client().makeRequest("POST", "$ALERTING_BASE_URI/$monitorId/_execute", params)
+        return executeMonitor(client(), monitorId, params)
     }
 
-    protected fun executeMonitor(monitor: Monitor, params: Map<String, String> = mapOf()): Response =
-            client().makeRequest("POST", "$ALERTING_BASE_URI/_execute", params, monitor.toHttpEntity())
+    protected fun executeMonitor(client: RestClient, monitorId: String, params: Map<String, String> = mutableMapOf()): Response {
+        return client.makeRequest("POST", "$ALERTING_BASE_URI/$monitorId/_execute", params)
+    }
+
+    protected fun executeMonitor(monitor: Monitor, params: Map<String, String> = mapOf()): Response {
+        return executeMonitor(client(), monitor, params)
+    }
+
+    protected fun executeMonitor(client: RestClient, monitor: Monitor, params: Map<String, String> = mapOf()): Response =
+            client.makeRequest("POST", "$ALERTING_BASE_URI/_execute", params, monitor.toHttpEntity())
 
     protected fun indexDoc(index: String, id: String, doc: String, refresh: Boolean = true): Response {
         val requestBody = StringEntity(doc, APPLICATION_JSON)
@@ -641,6 +650,73 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
             .filter { destinationType -> destinationType != DestinationType.EMAIL }
             .joinToString(prefix = "[", postfix = "]") { string -> "\"$string\"" }
         client().updateSettings(DestinationSettings.ALLOW_LIST.key, allowedDestinations)
+    }
+
+    fun createUser(name: String, passwd: String, backendRoles: Array<String>) {
+        val request = Request("PUT", "/_opendistro/_security/api/internalusers/$name")
+        val broles = backendRoles.joinToString { it -> "\"$it\"" }
+        var entity = " {\n" +
+                "\"password\": \"$passwd\",\n" +
+                "\"backend_roles\": [$broles],\n" +
+                "\"attributes\": {\n" +
+                "}} "
+        request.setJsonEntity(entity)
+        client().performRequest(request)
+    }
+
+    fun createIndexRole(name: String, index: String) {
+        val request = Request("PUT", "/_opendistro/_security/api/roles/$name")
+        var entity = "{\n" +
+                "\"cluster_permissions\": [\n" +
+                "],\n" +
+                "\"index_permissions\": [\n" +
+                "{\n" +
+                "\"index_patterns\": [\n" +
+                "\"$index\"\n" +
+                "],\n" +
+                "\"dls\": \"\",\n" +
+                "\"fls\": [],\n" +
+                "\"masked_fields\": [],\n" +
+                "\"allowed_actions\": [\n" +
+                "\"crud\"\n" +
+                "]\n" +
+                "}\n" +
+                "],\n" +
+                "\"tenant_permissions\": []\n" +
+                "}"
+        request.setJsonEntity(entity)
+        client().performRequest(request)
+    }
+
+    fun createUserRolesMapping(role: String, users: Array<String>) {
+        val request = Request("PUT", "/_opendistro/_security/api/rolesmapping/$role")
+        val usersStr = users.joinToString { it -> "\"$it\"" }
+        var entity = "{                                  \n" +
+                "  \"backend_roles\" : [  ],\n" +
+                "  \"hosts\" : [  ],\n" +
+                "  \"users\" : [$usersStr]\n" +
+                "}"
+        request.setJsonEntity(entity)
+        client().performRequest(request)
+    }
+
+    fun deleteUser(name: String) {
+        client().makeRequest("DELETE", "/_opendistro/_security/api/internalusers/$name")
+    }
+
+    fun deleteRole(name: String) {
+        client().makeRequest("DELETE", "/_opendistro/_security/api/roles/$name")
+    }
+
+    fun deleteRoleMapping(name: String) {
+        client().makeRequest("DELETE", "/_opendistro/_security/api/rolesmapping/$name")
+    }
+
+    fun createUserWithTestData(user: String, index: String, role: String, backendRole: String) {
+        createUser(user, user, arrayOf(backendRole))
+        createTestIndex(index)
+        createIndexRole(role, index)
+        createUserRolesMapping(role, arrayOf(user))
     }
 
     companion object {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -21,36 +21,37 @@ import com.amazon.opendistroforelasticsearch.commons.ConfigConstants.OPENDISTRO_
 import com.amazon.opendistroforelasticsearch.commons.ConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD
 import com.amazon.opendistroforelasticsearch.commons.ConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_PEMCERT_FILEPATH
 import com.amazon.opendistroforelasticsearch.commons.rest.SecureRestClientBuilder
-import org.apache.http.Header
 import org.apache.http.HttpHost
-import org.apache.http.auth.AuthScope
-import org.apache.http.auth.UsernamePasswordCredentials
-import org.apache.http.client.CredentialsProvider
-import org.apache.http.client.config.RequestConfig
-import org.apache.http.conn.ssl.NoopHostnameVerifier
-import org.apache.http.impl.client.BasicCredentialsProvider
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
-import org.apache.http.message.BasicHeader
-import org.apache.http.ssl.SSLContextBuilder
 import org.elasticsearch.client.Request
 import org.elasticsearch.client.RestClient
-import org.elasticsearch.client.RestClientBuilder
 import org.elasticsearch.common.io.PathUtils
 import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.unit.TimeValue
-import org.elasticsearch.common.util.concurrent.ThreadContext
 import org.elasticsearch.common.xcontent.DeprecationHandler
 import org.elasticsearch.common.xcontent.NamedXContentRegistry
 import org.elasticsearch.common.xcontent.XContentType
 import org.elasticsearch.test.rest.ESRestTestCase
 import org.junit.After
 import java.io.IOException
-import java.security.cert.X509Certificate
+
+/**
+ * Must support below 3 scenario runs:
+ * 1. Without Security plugin
+ * 2. With Security plugin and https
+ * 3. With Security plugin and http
+ *    Its possible to have security enabled with http transport.
+ *
+ * client() - > admin user
+ * adminClient() -> adminDN/super-admin user
+ */
 
 abstract class ODFERestTestCase : ESRestTestCase() {
 
     fun isHttps(): Boolean {
         return System.getProperty("https", "false")!!.toBoolean()
+    }
+
+    fun securityEnabled(): Boolean {
+        return System.getProperty("security", "false")!!.toBoolean()
     }
 
     override fun getProtocol(): String {
@@ -67,7 +68,7 @@ abstract class ODFERestTestCase : ESRestTestCase() {
 
     @Throws(IOException::class)
     @After
-    public open fun wipeAllODFEIndices() {
+    open fun wipeAllODFEIndices() {
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
 
         val xContentType = XContentType.fromMediaTypeOrFormat(response.entity.contentType.value)
@@ -91,7 +92,7 @@ abstract class ODFERestTestCase : ESRestTestCase() {
         return Settings
                 .builder()
                 .put("http.port", 9200)
-                .put(OPENDISTRO_SECURITY_SSL_HTTP_ENABLED, true)
+                .put(OPENDISTRO_SECURITY_SSL_HTTP_ENABLED, isHttps())
                 .put(OPENDISTRO_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "sample.pem")
                 .put(OPENDISTRO_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
                 .put(OPENDISTRO_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD, "changeit")
@@ -101,18 +102,20 @@ abstract class ODFERestTestCase : ESRestTestCase() {
 
     @Throws(IOException::class)
     override fun buildClient(settings: Settings, hosts: Array<HttpHost>): RestClient {
-        if (isHttps()) {
+        if (securityEnabled()) {
             val keystore = settings.get(OPENDISTRO_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH)
             return when (keystore != null) {
                 true -> {
+                    // create adminDN (super-admin) client
                     val uri = javaClass.classLoader.getResource("sample.pem").toURI()
                     val configPath = PathUtils.get(uri).parent.toAbsolutePath()
                     SecureRestClientBuilder(settings, configPath).setSocketTimeout(60000).build()
                 }
                 false -> {
+                    // create client with passed user
                     val userName = System.getProperty("user")
                     val password = System.getProperty("password")
-                    SecureRestClientBuilder(hosts, true, userName, password).setSocketTimeout(60000).build()
+                    SecureRestClientBuilder(hosts, isHttps(), userName, password).setSocketTimeout(60000).build()
                 }
             }
         } else {
@@ -120,39 +123,6 @@ abstract class ODFERestTestCase : ESRestTestCase() {
             configureClient(builder, settings)
             builder.setStrictDeprecationMode(true)
             return builder.build()
-        }
-    }
-
-    @Throws(IOException::class)
-    protected open fun configureHttpsClient(builder: RestClientBuilder, settings: Settings) {
-        val headers = ThreadContext.buildDefaultHeaders(settings)
-        val defaultHeaders = arrayOfNulls<Header>(headers.size)
-        var i = 0
-        for ((key, value) in headers) {
-            defaultHeaders[i++] = BasicHeader(key, value)
-        }
-        builder.setDefaultHeaders(defaultHeaders)
-        builder.setHttpClientConfigCallback { httpClientBuilder: HttpAsyncClientBuilder ->
-            val userName = System.getProperty("user")
-            val password = System.getProperty("password")
-            val credentialsProvider: CredentialsProvider = BasicCredentialsProvider()
-            credentialsProvider.setCredentials(AuthScope.ANY, UsernamePasswordCredentials(userName, password))
-            try {
-                return@setHttpClientConfigCallback httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
-                        // disable the certificate since our testing cluster just uses the default security configuration
-                        .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                        .setSSLContext(SSLContextBuilder.create()
-                                .loadTrustMaterial(null) { _: Array<X509Certificate?>?, _: String? -> true }
-                                .build())
-            } catch (e: Exception) {
-                throw RuntimeException(e)
-            }
-        }
-        val socketTimeoutString = settings[CLIENT_SOCKET_TIMEOUT]
-        val socketTimeout = TimeValue.parseTimeValue(socketTimeoutString ?: "60s", CLIENT_SOCKET_TIMEOUT)
-        builder.setRequestConfigCallback { conf: RequestConfig.Builder -> conf.setSocketTimeout(Math.toIntExact(socketTimeout.millis)) }
-        if (settings.hasValue(CLIENT_PATH_PREFIX)) {
-            builder.setPathPrefix(settings[CLIENT_PATH_PREFIX])
         }
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -39,7 +39,6 @@ import java.io.IOException
  * 2. With Security plugin and https
  * 3. With Security plugin and http
  *    Its possible to have security enabled with http transport.
- *
  * client() - > admin user
  * adminClient() -> adminDN/super-admin user
  */

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureDestinationRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureDestinationRestApiIT.kt
@@ -63,7 +63,7 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
                 customWebhook = null,
                 email = null)
 
-        if (isHttps()) {
+        if (securityEnabled()) {
             // when security is enabled. No errors, must succeed.
             val response = client().makeRequest(
                     "POST",
@@ -113,7 +113,7 @@ class SecureDestinationRestApiIT : AlertingRestTestCase() {
 
     fun `test get destinations with a destination type and filter by`() {
         enableFilterBy()
-        if (!isHttps()) {
+        if (!securityEnabled()) {
             // if security is disabled and filter by is enabled, we can't create monitor
             // refer: `test create destination with enable filter by`
             return

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -1,27 +1,129 @@
 package com.amazon.opendistroforelasticsearch.alerting.resthandler
 
 import com.amazon.opendistroforelasticsearch.alerting.ALERTING_BASE_URI
+import com.amazon.opendistroforelasticsearch.alerting.ALWAYS_RUN
 import com.amazon.opendistroforelasticsearch.alerting.AlertingRestTestCase
+import com.amazon.opendistroforelasticsearch.alerting.DRYRUN_MONITOR
+import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.makeRequest
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
+import com.amazon.opendistroforelasticsearch.alerting.randomAction
 import com.amazon.opendistroforelasticsearch.alerting.randomAlert
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
+import com.amazon.opendistroforelasticsearch.alerting.randomTemplateScript
+import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
+import com.amazon.opendistroforelasticsearch.commons.rest.SecureRestClientBuilder
 import org.apache.http.entity.ContentType
 import org.apache.http.nio.entity.NStringEntity
+import org.elasticsearch.client.Response
 import org.elasticsearch.client.ResponseException
+import org.elasticsearch.client.RestClient
 import org.elasticsearch.common.xcontent.XContentType
 import org.elasticsearch.index.query.QueryBuilders
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.elasticsearch.test.junit.annotations.TestLogging
+import org.junit.After
+import org.junit.Before
 
-/**
- * client() - created with admin
- * adminClient() - created with kirk adminDn certs. (super-admin)
- */
 @TestLogging("level:DEBUG", reason = "Debug for tests.")
 @Suppress("UNCHECKED_CAST")
 class SecureMonitorRestApiIT : AlertingRestTestCase() {
+
+    val user = "userOne"
+    var userClient: RestClient? = null
+
+    @Before
+    fun create() {
+        if (!securityEnabled()) return
+
+        if (userClient == null) {
+            createUser(user, user, arrayOf())
+            userClient = SecureRestClientBuilder(clusterHosts.toTypedArray(), isHttps(), user, user).setSocketTimeout(60000).build()
+        }
+    }
+
+    @After
+    fun cleanup() {
+        if (!securityEnabled()) return
+
+        userClient?.close()
+        deleteUser(user)
+    }
+
+    // Create Monitor related security tests
+
+    fun `test create monitor with an user with alerting role`() {
+        if (!securityEnabled()) return
+
+        createUserWithTestData(user, "hr_data", "hr_role", "HR")
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+        try {
+            // randomMonitor has a dummy user, api ignores the User passed as part of monitor, it picks user info from the logged-in user.
+            val monitor = randomMonitor().copy(
+                    inputs = listOf(SearchInput(
+                            indices = listOf("hr_data"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))))
+            val createResponse = userClient?.makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+            assertEquals("Create monitor failed", RestStatus.CREATED, createResponse?.restStatus())
+
+            // val newMonitor = getMonitor(userClient as RestClient, monitor.id)
+            val responseBody = createResponse?.asMap()
+            val monitorMap = responseBody!!["monitor"] as HashMap<String, Any>
+            val userMap = monitorMap["user"] as HashMap<String, Any>
+            assertEquals("User is not present", user, userMap["name"])
+
+            val brolesArray = userMap["backend_roles"] as ArrayList<String>
+            assertTrue(brolesArray.contains("HR"))
+
+            val rolesArray = userMap["roles"] as ArrayList<String>
+            assertTrue(rolesArray.contains("hr_role"))
+            assertTrue(rolesArray.contains("alerting_full_access"))
+        } finally {
+            deleteRoleMapping("hr_role")
+            deleteRole("hr_role")
+            deleteRoleMapping("alerting_full_access")
+        }
+    }
+
+    fun `test create monitor with an user with out alerting role`() {
+        if (!securityEnabled()) return
+
+        createUserWithTestData(user, "hr_data", "hr_role", "HR")
+        try {
+            val monitor = randomMonitor().copy(
+                    inputs = listOf(SearchInput(
+                            indices = listOf("hr_data"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))))
+            userClient?.makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+            fail("Expected 403 Method FORBIDDEN response")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        } finally {
+            deleteRoleMapping("hr_role")
+            deleteRole("hr_role")
+        }
+    }
+
+    fun `test create monitor with an user with out index read role`() {
+        if (!securityEnabled()) return
+
+        createUserWithTestData(user, "hr_data", "hr_role", "HR")
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+        try {
+            val monitor = randomMonitor().copy(
+                    inputs = listOf(SearchInput(
+                            indices = listOf("not_hr_data"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))))
+            val createResponse = userClient?.makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+            assertEquals("Create monitor failed", RestStatus.CREATED, createResponse?.restStatus())
+            fail("Expected 403 Method FORBIDDEN response")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        } finally {
+            deleteRoleMapping("hr_role")
+            deleteRole("hr_role")
+            deleteRoleMapping("alerting_full_access")
+        }
+    }
 
     fun `test create monitor with disable filter by`() {
         disableFilterBy()
@@ -34,7 +136,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         enableFilterBy()
         val monitor = randomMonitor()
 
-        if (isHttps()) {
+        if (securityEnabled()) {
             // when security is enabled. No errors, must succeed.
             val createResponse = client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
             assertEquals("Create monitor failed", RestStatus.CREATED, createResponse.restStatus())
@@ -49,8 +151,19 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
+    fun getDocs(response: Response?): Any? {
+        val hits = createParser(XContentType.JSON.xContent(),
+                response?.entity?.content).map()["hits"]!! as Map<String, Map<String, Any>>
+        return hits["total"]?.get("value")
+    }
+
+    // Query Monitors related security tests
+
     fun `test query monitors with disable filter by`() {
+        if (!securityEnabled()) return
+
         disableFilterBy()
+
         // creates monitor as "admin" user.
         val monitor = createRandomMonitor(true)
         val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitor.id)).toString()
@@ -61,40 +174,76 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
                 emptyMap(),
                 NStringEntity(search, ContentType.APPLICATION_JSON))
         assertEquals("Search monitor failed", RestStatus.OK, adminSearchResponse.restStatus())
+        assertEquals("Monitor not found during search", 1, getDocs(adminSearchResponse))
 
-        val adminHits = createParser(XContentType.JSON.xContent(),
-                adminSearchResponse.entity.content).map()["hits"]!! as Map<String, Map<String, Any>>
-        val adminDocsFound = adminHits["total"]?.get("value")
-        assertEquals("Monitor not found during search", 1, adminDocsFound)
+        // search as userOne without alerting roles - must return 403 Forbidden
+        try {
+            userClient?.makeRequest("POST", "$ALERTING_BASE_URI/_search",
+                    emptyMap(),
+                    NStringEntity(search, ContentType.APPLICATION_JSON))
+            fail("Expected 403 FORBIDDEN response")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        }
+
+        // add alerting roles and search as userOne - must return 1 docs
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+        try {
+            val userOneSearchResponse = userClient?.makeRequest("POST",
+                    "$ALERTING_BASE_URI/_search",
+                    emptyMap(),
+                    NStringEntity(search, ContentType.APPLICATION_JSON))
+            assertEquals("Search monitor failed", RestStatus.OK, userOneSearchResponse?.restStatus())
+            assertEquals("Monitor not found during search", 1, getDocs(userOneSearchResponse))
+        } finally {
+            deleteRoleMapping("alerting_full_access")
+        }
     }
 
     fun `test query monitors with enable filter by`() {
-        enableFilterBy()
+        if (!securityEnabled()) return
 
-        if (!isHttps()) {
-            // if security is disabled and filter by is enabled, we can't create monitor
-            // refer: `test create monitor with enable filter by`
-            return
-        }
+        enableFilterBy()
 
         // creates monitor as "admin" user.
         val monitor = createRandomMonitor(true)
         val search = SearchSourceBuilder().query(QueryBuilders.termQuery("_id", monitor.id)).toString()
 
         // search as "admin" - must get 1 docs
-        val adminSearchResponse = client().makeRequest("POST", "$ALERTING_BASE_URI/_search",
+        val adminSearchResponse = client().makeRequest("POST",
+                "$ALERTING_BASE_URI/_search",
                 emptyMap(),
-                NStringEntity(search, ContentType.APPLICATION_JSON)
-        )
+                NStringEntity(search, ContentType.APPLICATION_JSON))
         assertEquals("Search monitor failed", RestStatus.OK, adminSearchResponse.restStatus())
+        assertEquals("Monitor not found during search", 1, getDocs(adminSearchResponse))
 
-        val adminHits = createParser(XContentType.JSON.xContent(),
-                adminSearchResponse.entity.content).map()["hits"]!! as Map<String, Map<String, Any>>
-        val adminDocsFound = adminHits["total"]?.get("value")
-        assertEquals("Monitor not found during search", 1, adminDocsFound)
+        // search as userOne without alerting roles - must return 403 Forbidden
+        try {
+            userClient?.makeRequest("POST", "$ALERTING_BASE_URI/_search",
+                    emptyMap(),
+                    NStringEntity(search, ContentType.APPLICATION_JSON))
+            fail("Expected 403 FORBIDDEN response")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        }
+
+        // add alerting roles and search as userOne - must return 0 docs
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+        try {
+            val userOneSearchResponse = userClient?.makeRequest("POST",
+                    "$ALERTING_BASE_URI/_search",
+                    emptyMap(),
+                    NStringEntity(search, ContentType.APPLICATION_JSON))
+            assertEquals("Search monitor failed", RestStatus.OK, userOneSearchResponse?.restStatus())
+            assertEquals("Monitor not found during search", 0, getDocs(userOneSearchResponse))
+        } finally {
+            deleteRoleMapping("alerting_full_access")
+        }
     }
 
-    fun `test get all alerts in all states with disabled filter by`() {
+    fun `test query all alerts in all states with disabled filter by`() {
+        if (!securityEnabled()) return
+
         disableFilterBy()
         putAlertMappings()
         val monitor = createRandomMonitor(refresh = true)
@@ -110,14 +259,30 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         // search as "admin" - must get 4 docs
         val adminResponseMap = getAlerts(client(), inputMap).asMap()
         assertEquals(4, adminResponseMap["totalAlerts"])
+
+        // search as userOne without alerting roles - must return 403 Forbidden
+        try {
+            getAlerts(userClient as RestClient, inputMap).asMap()
+            fail("Expected 403 FORBIDDEN response")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        }
+
+        // add alerting roles and search as userOne - must return 0 docs
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+        try {
+            val responseMap = getAlerts(userClient as RestClient, inputMap).asMap()
+            assertEquals(4, responseMap["totalAlerts"])
+        } finally {
+            deleteRoleMapping("alerting_full_access")
+        }
     }
 
-    fun `test get all alerts in all states with filter by`() {
-        if (!isHttps()) {
-            // if security is disabled and filter by is enabled, we can't create monitor
-            // refer: `test create monitor with enable filter by`
-            return
-        }
+    fun `test query all alerts in all states with filter by`() {
+        // if security is disabled and filter by is enabled, we can't create monitor
+        // refer: `test create monitor with enable filter by`
+        if (!securityEnabled()) return
+
         enableFilterBy()
         putAlertMappings()
         val monitor = createRandomMonitor(refresh = true)
@@ -133,5 +298,52 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         // search as "admin" - must get 4 docs
         val adminResponseMap = getAlerts(client(), inputMap).asMap()
         assertEquals(4, adminResponseMap["totalAlerts"])
+
+        // search as userOne without alerting roles - must return 403 Forbidden
+        try {
+            getAlerts(userClient as RestClient, inputMap).asMap()
+            fail("Expected 403 FORBIDDEN response")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected status", RestStatus.FORBIDDEN, e.response.restStatus())
+        }
+
+        // add alerting roles and search as userOne - must return 0 docs
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+        try {
+            val responseMap = getAlerts(userClient as RestClient, inputMap).asMap()
+            assertEquals(0, responseMap["totalAlerts"])
+        } finally {
+            deleteRoleMapping("alerting_full_access")
+        }
+    }
+
+    // Execute Monitor related security tests
+
+    fun `test execute monitor with elevate permissions`() {
+        if (!securityEnabled()) return
+
+        val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name}}"), destinationId = createDestination().id)
+        val inputs = listOf(
+                SearchInput(
+                        indices = kotlin.collections.listOf("not_hr_data"),
+                        query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
+                )
+        )
+        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))), inputs = inputs)
+
+        // Make sure the elevating the permissions fails execute.
+        val adminUser = User("admin", listOf("admin"), listOf("all_access"), listOf())
+        var modifiedMonitor = monitor.copy(user = adminUser)
+        createUserRolesMapping("alerting_full_access", arrayOf(user))
+
+        try {
+            val response = executeMonitor(userClient as RestClient, modifiedMonitor, params = DRYRUN_MONITOR)
+            val output = entityAsMap(response)
+            val inputResults = output.stringMap("input_results")
+            assertTrue("Missing monitor error message", (inputResults?.get("error") as String).isNotEmpty())
+            assertTrue((inputResults.get("error") as String).contains("no permissions for [indices:data/read/search]"))
+        } finally {
+            deleteRoleMapping("alerting_full_access")
+        }
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -86,7 +86,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test create monitor with an user with out alerting role`() {
+    fun `test create monitor with an user without alerting role`() {
         if (!securityEnabled()) return
 
         createUserWithTestData(user, "hr_data", "hr_role", "HR")
@@ -104,7 +104,7 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
         }
     }
 
-    fun `test create monitor with an user with out index read role`() {
+    fun `test create monitor with an user without index read role`() {
         if (!securityEnabled()) return
 
         createUserWithTestData(user, "hr_data", "hr_role", "HR")


### PR DESCRIPTION
*Issue #, if available:*
Add integ security tests with a limited user

*Description of changes:*
So far security tests are run with admin user. In additional to running all tests as admin user, this PR adds tests which are run with a user with limited permissions. 

`./gradlew :alerting:integTestRunner -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin -Dsecurity=true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
