### PR TITLE
fix failed IT cases for AD

### DIFF
--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
@@ -654,92 +654,104 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test execute AD monitor doesn't return search result without user`() {
-        val user = randomUser()
-        val detectorId = randomAlphaOfLength(5)
-        prepareTestAnomalyResult(detectorId, user)
-        // for old monitor before enable FGAC, the user field is empty
-        val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)), triggers = listOf(adMonitorTrigger()), user = null)
-        val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
-        val output = entityAsMap(response)
-        @Suppress("UNCHECKED_CAST")
-        (output["trigger_results"] as HashMap<String, Any>).forEach {
-            _, v -> assertTrue((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+        // TODO: change to REST API call to test security enabled case
+        if (!securityEnabled()) {
+            val user = randomUser()
+            val detectorId = randomAlphaOfLength(5)
+            prepareTestAnomalyResult(detectorId, user)
+            // for old monitor before enable FGAC, the user field is empty
+            val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)), triggers = listOf(adMonitorTrigger()), user = null)
+            val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
+            val output = entityAsMap(response)
+            @Suppress("UNCHECKED_CAST")
+            (output["trigger_results"] as HashMap<String, Any>).forEach {
+                _, v -> assertTrue((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+            }
+            assertEquals(monitor.name, output["monitor_name"])
+            @Suppress("UNCHECKED_CAST")
+            val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+            @Suppress("UNCHECKED_CAST")
+            val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
+            assertEquals("Incorrect search result", 1, total["value"])
+            @Suppress("UNCHECKED_CAST")
+            val maxAnomalyGrade = searchResult.stringMap("aggregations")?.get("max_anomaly_grade") as Map<String, String>
+            assertEquals("Incorrect search result", 0.75, maxAnomalyGrade["value"])
         }
-        assertEquals(monitor.name, output["monitor_name"])
-        @Suppress("UNCHECKED_CAST")
-        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
-        @Suppress("UNCHECKED_CAST")
-        val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
-        assertEquals("Incorrect search result", 1, total["value"])
-        @Suppress("UNCHECKED_CAST")
-        val maxAnomalyGrade = searchResult.stringMap("aggregations")?.get("max_anomaly_grade") as Map<String, String>
-        assertEquals("Incorrect search result", 0.75, maxAnomalyGrade["value"])
     }
 
     fun `test execute AD monitor doesn't return search result with empty backend role`() {
-        val user = randomUser()
-        val detectorId = randomAlphaOfLength(5)
-        prepareTestAnomalyResult(detectorId, user)
-        // for old monitor before enable FGAC, the user field is empty
-        val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)), triggers = listOf(adMonitorTrigger()),
-                user = User(user.name, listOf(), user.roles, user.customAttNames))
-        val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
-        val output = entityAsMap(response)
-        @Suppress("UNCHECKED_CAST")
-        (output["trigger_results"] as HashMap<String, Any>).forEach {
-            _, v -> assertTrue((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+        // TODO: change to REST API call to test security enabled case
+        if (!securityEnabled()) {
+            val user = randomUser()
+            val detectorId = randomAlphaOfLength(5)
+            prepareTestAnomalyResult(detectorId, user)
+            // for old monitor before enable FGAC, the user field is empty
+            val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)), triggers = listOf(adMonitorTrigger()),
+                    user = User(user.name, listOf(), user.roles, user.customAttNames))
+            val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
+            val output = entityAsMap(response)
+            @Suppress("UNCHECKED_CAST")
+            (output["trigger_results"] as HashMap<String, Any>).forEach {
+                _, v -> assertTrue((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+            }
+            assertEquals(monitor.name, output["monitor_name"])
+            @Suppress("UNCHECKED_CAST")
+            val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+            @Suppress("UNCHECKED_CAST")
+            val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
+            assertEquals("Incorrect search result", 1, total["value"])
+            @Suppress("UNCHECKED_CAST")
+            val maxAnomalyGrade = searchResult.stringMap("aggregations")?.get("max_anomaly_grade") as Map<String, String>
+            assertEquals("Incorrect search result", 0.9, maxAnomalyGrade["value"])
         }
-        assertEquals(monitor.name, output["monitor_name"])
-        @Suppress("UNCHECKED_CAST")
-        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
-        @Suppress("UNCHECKED_CAST")
-        val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
-        assertEquals("Incorrect search result", 1, total["value"])
-        @Suppress("UNCHECKED_CAST")
-        val maxAnomalyGrade = searchResult.stringMap("aggregations")?.get("max_anomaly_grade") as Map<String, String>
-        assertEquals("Incorrect search result", 0.9, maxAnomalyGrade["value"])
     }
 
     fun `test execute AD monitor returns search result with same backend role`() {
-        val detectorId = randomAlphaOfLength(5)
-        val user = randomUser()
-        prepareTestAnomalyResult(detectorId, user)
-        // Test monitor with same user
-        val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)), triggers = listOf(adMonitorTrigger()), user = user)
-        val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
-        val output = entityAsMap(response)
-        @Suppress("UNCHECKED_CAST")
-        (output["trigger_results"] as HashMap<String, Any>).forEach {
-            _, v -> assertTrue((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+        // TODO: change to REST API call to test security enabled case
+        if (!securityEnabled()) {
+            val detectorId = randomAlphaOfLength(5)
+            val user = randomUser()
+            prepareTestAnomalyResult(detectorId, user)
+            // Test monitor with same user
+            val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)), triggers = listOf(adMonitorTrigger()), user = user)
+            val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
+            val output = entityAsMap(response)
+            @Suppress("UNCHECKED_CAST")
+            (output["trigger_results"] as HashMap<String, Any>).forEach {
+                _, v -> assertTrue((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+            }
+            @Suppress("UNCHECKED_CAST")
+            val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+            @Suppress("UNCHECKED_CAST")
+            val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
+            assertEquals("Incorrect search result", 3, total["value"])
+            @Suppress("UNCHECKED_CAST")
+            val maxAnomalyGrade = searchResult.stringMap("aggregations")?.get("max_anomaly_grade") as Map<String, String>
+            assertEquals("Incorrect search result", 0.8, maxAnomalyGrade["value"])
         }
-        @Suppress("UNCHECKED_CAST")
-        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
-        @Suppress("UNCHECKED_CAST")
-        val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
-        assertEquals("Incorrect search result", 3, total["value"])
-        @Suppress("UNCHECKED_CAST")
-        val maxAnomalyGrade = searchResult.stringMap("aggregations")?.get("max_anomaly_grade") as Map<String, String>
-        assertEquals("Incorrect search result", 0.8, maxAnomalyGrade["value"])
     }
 
     fun `test execute AD monitor returns no search result with different backend role`() {
-        val detectorId = randomAlphaOfLength(5)
-        val user = randomUser()
-        prepareTestAnomalyResult(detectorId, user)
-        // Test monitor with different user
-        val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)),
-                triggers = listOf(adMonitorTrigger()), user = randomUser())
-        val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
-        val output = entityAsMap(response)
-        @Suppress("UNCHECKED_CAST")
-        (output["trigger_results"] as HashMap<String, Any>).forEach {
-            _, v -> assertFalse((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+        // TODO: change to REST API call to test security enabled case
+        if (!securityEnabled()) {
+            val detectorId = randomAlphaOfLength(5)
+            val user = randomUser()
+            prepareTestAnomalyResult(detectorId, user)
+            // Test monitor with different user
+            val monitor = randomADMonitor(inputs = listOf(adSearchInput(detectorId)),
+                    triggers = listOf(adMonitorTrigger()), user = randomUser())
+            val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
+            val output = entityAsMap(response)
+            @Suppress("UNCHECKED_CAST")
+            (output["trigger_results"] as HashMap<String, Any>).forEach {
+                _, v -> assertFalse((v as HashMap<String, Boolean>)["triggered"] as Boolean)
+            }
+            @Suppress("UNCHECKED_CAST")
+            val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
+            @Suppress("UNCHECKED_CAST")
+            val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
+            assertEquals("Incorrect search result", 0, total["value"])
         }
-        @Suppress("UNCHECKED_CAST")
-        val searchResult = (output.objectMap("input_results")["results"] as List<Map<String, Any>>).first()
-        @Suppress("UNCHECKED_CAST")
-        val total = searchResult.stringMap("hits")?.get("total") as Map<String, String>
-        assertEquals("Incorrect search result", 0, total["value"])
     }
 
     private fun prepareTestAnomalyResult(detectorId: String, user: User) {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ODFERestTestCase.kt
@@ -23,7 +23,9 @@ import com.amazon.opendistroforelasticsearch.commons.ConfigConstants.OPENDISTRO_
 import com.amazon.opendistroforelasticsearch.commons.rest.SecureRestClientBuilder
 import org.apache.http.HttpHost
 import org.elasticsearch.client.Request
+import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.RestClient
+import org.elasticsearch.client.WarningsHandler
 import org.elasticsearch.common.io.PathUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.xcontent.DeprecationHandler
@@ -79,9 +81,15 @@ abstract class ODFERestTestCase : ESRestTestCase() {
                 val indexName: String = jsonObject["index"] as String
                 // .opendistro_security isn't allowed to delete from cluster
                 if (".opendistro_security" != indexName) {
-                    adminClient().performRequest(Request("DELETE", "/$indexName"))
+                    var request = Request("DELETE", "/$indexName")
+                    // TODO: remove PERMISSIVE option after moving system index access to REST API call
+                    val options = RequestOptions.DEFAULT.toBuilder()
+                    options.setWarningsHandler(WarningsHandler.PERMISSIVE)
+                    request.options = options.build()
+                    adminClient().performRequest(request)
                 }
-            } }
+            }
+        }
     }
 
     /**

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -39,6 +39,7 @@ import org.elasticsearch.client.Request
 import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.Response
 import org.elasticsearch.client.RestClient
+import org.elasticsearch.client.WarningsHandler
 import org.elasticsearch.common.UUIDs
 import org.elasticsearch.common.settings.SecureString
 import org.elasticsearch.common.settings.Settings
@@ -252,7 +253,9 @@ fun RestClient.makeRequest(
     vararg headers: Header
 ): Response {
     val request = Request(method, endpoint)
+    // TODO: remove PERMISSIVE option after moving system index access to REST API call
     val options = RequestOptions.DEFAULT.toBuilder()
+    options.setWarningsHandler(WarningsHandler.PERMISSIVE)
     headers.forEach { options.addHeader(it.name, it.value) }
     request.options = options.build()
     params.forEach { request.addParameter(it.key, it.value) }
@@ -276,6 +279,8 @@ fun RestClient.makeRequest(
 ): Response {
     val request = Request(method, endpoint)
     val options = RequestOptions.DEFAULT.toBuilder()
+    // TODO: remove PERMISSIVE option after moving system index access to REST API call
+    options.setWarningsHandler(WarningsHandler.PERMISSIVE)
     headers.forEach { options.addHeader(it.name, it.value) }
     request.options = options.build()
     if (entity != null) {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -187,17 +187,20 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     }
 
     fun `test creating an AD monitor with no detector has monitor backend role`() {
-        createAnomalyDetectorIndex()
-        indexDoc(ANOMALY_DETECTOR_INDEX, "1", randomAnomalyDetector())
-        indexDoc(ANOMALY_DETECTOR_INDEX, "2", randomAnomalyDetectorWithUser(randomAlphaOfLength(5)))
-        try {
-            val monitor = randomADMonitor()
-            client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
-        } catch (e: ResponseException) {
-            // When user create AD monitor with no detector has backend role, will throw exception
-            assertTrue("Unexpected error", e.message!!.contains("User has no available detectors"))
-            assertTrue("Unexpected status",
-                    listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+        if (!securityEnabled()) {
+            createAnomalyDetectorIndex()
+            // TODO: change to REST API call to test security enabled case
+            indexDoc(ANOMALY_DETECTOR_INDEX, "1", randomAnomalyDetector())
+            indexDoc(ANOMALY_DETECTOR_INDEX, "2", randomAnomalyDetectorWithUser(randomAlphaOfLength(5)))
+            try {
+                val monitor = randomADMonitor()
+                client().makeRequest("POST", ALERTING_BASE_URI, emptyMap(), monitor.toHttpEntity())
+            } catch (e: ResponseException) {
+                // When user create AD monitor with no detector has backend role, will throw exception
+                assertTrue("Unexpected error", e.message!!.contains("User has no available detectors"))
+                assertTrue("Unexpected status",
+                        listOf<RestStatus>(RestStatus.NOT_FOUND).contains(e.response.restStatus()))
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix failed IT cases for AD monitor. 

Test with security enabled
./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin -Dsecurity=true

Test with security disabled
./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
