### PR TITLE
Add check to Destination to block reserved IP addresses

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -11,7 +11,7 @@
 ** kotlin-test; version 1.2.60 -- https://github.com/JetBrains/kotlin/tree/1.2.60
 ** kotlin-test-junit; version 1.2.60 -- https://github.com/JetBrains/kotlin/tree/1.2.60
 ** Maven-org-jetbrains_annotations; version 13.0 -- http://www.jetbrains.org/display/IJOS/Home;jsessionid=1881AA3B9F1A3A8D98C0EDD69082DC85
-** PowerMock; version 1.7.4 -- http://www.powermock.org
+** PowerMock; version 2.0.2 -- http://www.powermock.org
 ** JavaMail; version 1.6.2 -- https://javaee.github.io/javamail/
 
 Apache License

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -21,9 +21,9 @@ apply plugin: 'signing'
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
-    compile group: 'commons-net', name: 'commons-net', version: '3.6'
     compile "org.apache.httpcomponents:httpcore:4.4.5"
     compile "org.apache.httpcomponents:httpclient:4.5.10"
+    compile "commons-net:commons-net:3.6"
     compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -21,11 +21,13 @@ apply plugin: 'signing'
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
+    compile group: 'commons-net', name: 'commons-net', version: '3.6'
     compile "org.apache.httpcomponents:httpcore:4.4.5"
     compile "org.apache.httpcomponents:httpclient:4.5.10"
     compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
+    testImplementation "org.powermock:powermock-api-easymock:1.7.4"
     testImplementation "org.easymock:easymock:4.0.1"
 }
 

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     testImplementation "org.elasticsearch.test:framework:${es_version}"
     testImplementation "org.powermock:powermock-api-easymock:1.7.4"
     testImplementation "org.easymock:easymock:4.0.1"
+    testCompile group: 'org.powermock', name: 'powermock-easymock-release-full', version: '1.6.4', ext: 'pom'
+    testCompile group: 'org.powermock', name: 'powermock-api-easymock', version: '2.0.2'
+    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.2'
 }
 
 shadowJar {

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -27,11 +27,9 @@ dependencies {
     compile "com.sun.mail:javax.mail:1.6.2"
 
     testImplementation "org.elasticsearch.test:framework:${es_version}"
-    testImplementation "org.powermock:powermock-api-easymock:1.7.4"
     testImplementation "org.easymock:easymock:4.0.1"
-    testCompile group: 'org.powermock', name: 'powermock-easymock-release-full', version: '1.6.4', ext: 'pom'
-    testCompile group: 'org.powermock', name: 'powermock-api-easymock', version: '2.0.2'
-    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.2'
+    testImplementation "org.powermock:powermock-api-easymock:2.0.2"
+    testImplementation "org.powermock:powermock-module-junit4:2.0.2"
 }
 
 shadowJar {

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
@@ -66,7 +66,7 @@ public class DestinationHttpClient {
     private static final int TIMEOUT_MILLISECONDS = (int) TimeValue.timeValueSeconds(5).millis();
     private static final int SOCKET_TIMEOUT_MILLISECONDS = (int)TimeValue.timeValueSeconds(50).millis();
 
-    private static final List<String> blacklistRanges = new ArrayList<>(
+    private static final List<String> blocklistRanges = new ArrayList<>(
             Arrays.asList(
                 //Loopback
                 "127.0.0.0/8",
@@ -150,10 +150,10 @@ public class DestinationHttpClient {
         }
 
         SubnetUtils utils;
-        for (String range : blacklistRanges) {
+        for (String range : blocklistRanges) {
             utils = new SubnetUtils(range);
             if (utils.getInfo().isInRange(InetAddress.getByName(uri.getHost()).getHostAddress())) {
-                logger.error("Host: {} resolves to: {} which is in blacklist: {}.", uri.getHost(), InetAddress.getByName(uri.getHost()), range);
+                logger.error("Host: {} resolves to: {} which is in blocklist: {}.", uri.getHost(), InetAddress.getByName(uri.getHost()), range);
                 throw new IllegalArgumentException("The destination address is invalid.");
             }
         }

--- a/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
+++ b/notification/src/main/java/com/amazon/opendistroforelasticsearch/alerting/destination/client/DestinationHttpClient.java
@@ -70,7 +70,7 @@ public class DestinationHttpClient {
             Arrays.asList(
                 //Loopback
                 "127.0.0.0/8",
-                //AWS internal IP range
+                //Link-local address
                 "169.254.0.0/16",
                 //Reserved IP address
                 "0.0.0.0/8",

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/ChimeDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/ChimeDestinationTest.java
@@ -67,7 +67,7 @@ public class ChimeDestinationTest {
                 "link test: http://sample.com email test: marymajor@example.com All member callout: " +
                 "@All All Present member callout: @Present\"}";
         BaseMessage bm = new ChimeMessage.Builder("abc").withMessage(message).
-                withUrl("https://abc/com").build();
+                withUrl("https://abc.com").build();
         DestinationResponse actualChimeResponse = (DestinationResponse) Notification.publish(bm);
 
         assertEquals(expectedChimeResponse.getResponseContent(), actualChimeResponse.getResponseContent());
@@ -105,7 +105,7 @@ public class ChimeDestinationTest {
                 "link test: http://sample.com email test: marymajor@example.com All member callout: " +
                 "@All All Present member callout: @Present\"}";
         BaseMessage bm = new ChimeMessage.Builder("abc").withMessage(message).
-                withUrl("https://abc/com").build();
+                withUrl("https://abc.com").build();
         DestinationResponse actualChimeResponse = (DestinationResponse) Notification.publish(bm);
 
         assertEquals(expectedChimeResponse.getResponseContent(), actualChimeResponse.getResponseContent());
@@ -143,7 +143,7 @@ public class ChimeDestinationTest {
                 "link test: http://sample.com email test: marymajor@example.com All member callout: " +
                 "@All All Present member callout: @Present\"}";
         BaseMessage bm = new ChimeMessage.Builder("abc").withMessage(message).
-                withUrl("https://abc/com").build();
+                withUrl("https://abc.com").build();
         DestinationResponse actualChimeResponse = (DestinationResponse) Notification.publish(bm);
 
         assertEquals(expectedChimeResponse.getResponseContent(), actualChimeResponse.getResponseContent());
@@ -153,8 +153,7 @@ public class ChimeDestinationTest {
     @Test(expected = IllegalArgumentException.class)
     public void testUrlMissingMessage() {
         try {
-            ChimeMessage message = new ChimeMessage.Builder("chime")
-                    .withMessage("dummyMessage").build();
+            ChimeMessage message = new ChimeMessage.Builder("chime").withMessage("dummyMessage").build();
         } catch (Exception ex) {
             assertEquals("url is invalid or empty", ex.getMessage());
             throw ex;
@@ -164,8 +163,7 @@ public class ChimeDestinationTest {
     @Test(expected = IllegalArgumentException.class)
     public void testContentMissingMessage() {
         try {
-            ChimeMessage message = new ChimeMessage.Builder("chime")
-                    .withUrl("abc.com").build();
+            ChimeMessage message = new ChimeMessage.Builder("chime").withUrl("abc.com").build();
         } catch (Exception ex) {
             assertEquals("Message content is missing", ex.getMessage());
             throw ex;

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/ChimeDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/ChimeDestinationTest.java
@@ -30,10 +30,26 @@ import org.apache.http.message.BasicStatusLine;
 import org.easymock.EasyMock;
 import org.elasticsearch.rest.RestStatus;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.InetAddress;
+
+import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replayAll;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DestinationHttpClient.class, ChimeDestinationFactory.class, InetAddress.class})
+@PowerMockIgnore({"javax.net.ssl.*"})
 public class ChimeDestinationTest {
+
+    @Mock
+    InetAddress inetAddress;
 
     @Test
     public void testChimeMessage_NullEntityResponse() throws Exception {
@@ -55,6 +71,11 @@ public class ChimeDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
+
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("34.216.127.34").anyTimes(); // abc.com IP
+        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -131,6 +152,11 @@ public class ChimeDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
+
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("34.216.127.34").anyTimes(); // abc.com IP
+        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/ChimeDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/ChimeDestinationTest.java
@@ -29,6 +29,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.easymock.EasyMock;
 import org.elasticsearch.rest.RestStatus;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -51,6 +52,14 @@ public class ChimeDestinationTest {
     @Mock
     InetAddress inetAddress;
 
+    @Before
+    public void start() throws Exception {
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
+        replayAll();
+    }
+
     @Test
     public void testChimeMessage_NullEntityResponse() throws Exception {
         CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
@@ -71,11 +80,6 @@ public class ChimeDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("34.216.127.34").anyTimes(); // abc.com IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -152,11 +156,6 @@ public class ChimeDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("34.216.127.34").anyTimes(); // abc.com IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/CustomWebhookMessageTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/CustomWebhookMessageTest.java
@@ -223,7 +223,7 @@ public class CustomWebhookMessageTest {
     }
 
     @Test
-    public void testCustomWebhookMessageBlackList() throws Exception {
+    public void testCustomWebhookMessageBlockList() throws Exception {
         CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
 
         CloseableHttpResponse httpResponse = EasyMock.createMock(CloseableHttpResponse.class);
@@ -253,7 +253,7 @@ public class CustomWebhookMessageTest {
                 "All member callout: @All All Present member callout: @Present\"}";
         BaseMessage bm;
 
-        final List<String> blacklistIps = new ArrayList<>(
+        final List<String> blocklistIps = new ArrayList<>(
                 Arrays.asList(
                         "127.0.0.1", // 127.0.0.0/8
                         "169.254.0.1", // 169.254.0.0/16
@@ -269,7 +269,7 @@ public class CustomWebhookMessageTest {
                         "240.0.0.1") // 240.0.0.0/4
                 );
 
-        for (String ip : blacklistIps) {
+        for (String ip : blocklistIps) {
             mockStatic(InetAddress.class);
             expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
             expect(inetAddress.getHostAddress()).andReturn(ip).anyTimes();

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/CustomWebhookMessageTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/CustomWebhookMessageTest.java
@@ -32,6 +32,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.easymock.EasyMock;
 import org.elasticsearch.rest.RestStatus;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -80,6 +81,14 @@ public class CustomWebhookMessageTest {
     @Mock
     InetAddress inetAddress;
 
+    @Before
+    public void start() throws Exception {
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
+        replayAll();
+    }
+
     @Test
     public void testCustomWebhookMessage_NullEntityResponse() throws Exception {
         CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
@@ -101,11 +110,6 @@ public class CustomWebhookMessageTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -149,11 +153,6 @@ public class CustomWebhookMessageTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -199,11 +198,6 @@ public class CustomWebhookMessageTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/SlackDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/SlackDestinationTest.java
@@ -29,12 +29,27 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.easymock.EasyMock;
 import org.elasticsearch.rest.RestStatus;
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.InetAddress;
+
+import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replayAll;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DestinationHttpClient.class, SlackDestinationFactory.class, InetAddress.class})
+@PowerMockIgnore({"javax.net.ssl.*"})
 public class SlackDestinationTest {
+
+    @Mock
+    InetAddress inetAddress;
 
     @Test
     public void testSlackMessage_NullEntityResponse() throws Exception {
@@ -56,6 +71,11 @@ public class SlackDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
+
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
+        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -95,6 +115,11 @@ public class SlackDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
+
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
+        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -137,6 +162,11 @@ public class SlackDestinationTest {
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
 
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
+        replayAll();
+
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
         SlackDestinationFactory slackDestinationFactory = new SlackDestinationFactory();
@@ -159,10 +189,9 @@ public class SlackDestinationTest {
     @Test(expected = IllegalArgumentException.class)
     public void testUrlMissingMessage() {
         try {
-            SlackMessage message = new SlackMessage.Builder("slack")
-                    .withMessage("dummyMessage").build();
+            SlackMessage message = new SlackMessage.Builder("slack").withMessage("dummyMessage").build();
         } catch (Exception ex) {
-            Assert.assertEquals("url is invalid or empty", ex.getMessage());
+            assertEquals("url is invalid or empty", ex.getMessage());
             throw ex;
         }
     }
@@ -170,8 +199,7 @@ public class SlackDestinationTest {
     @Test(expected = IllegalArgumentException.class)
     public void testContentMissingMessage() {
         try {
-            SlackMessage message = new SlackMessage.Builder("slack")
-                    .withUrl("abc.com").build();
+            SlackMessage message = new SlackMessage.Builder("slack").withUrl("abc.com").build();
         } catch (Exception ex) {
             assertEquals("Message content is missing", ex.getMessage());
             throw ex;

--- a/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/SlackDestinationTest.java
+++ b/notification/src/test/java/com/amazon/opendistroforelasticsearch/alerting/destination/SlackDestinationTest.java
@@ -29,6 +29,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.easymock.EasyMock;
 import org.elasticsearch.rest.RestStatus;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -51,6 +52,14 @@ public class SlackDestinationTest {
     @Mock
     InetAddress inetAddress;
 
+    @Before
+    public void start() throws Exception {
+        mockStatic(InetAddress.class);
+        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
+        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
+        replayAll();
+    }
+
     @Test
     public void testSlackMessage_NullEntityResponse() throws Exception {
         CloseableHttpClient mockHttpClient = EasyMock.createMock(CloseableHttpClient.class);
@@ -71,11 +80,6 @@ public class SlackDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -115,11 +119,6 @@ public class SlackDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);
@@ -161,11 +160,6 @@ public class SlackDestinationTest {
         EasyMock.replay(mockHttpClient);
         EasyMock.replay(httpResponse);
         EasyMock.replay(mockStatusLine);
-
-        mockStatic(InetAddress.class);
-        expect(InetAddress.getByName(EasyMock.anyString())).andReturn(inetAddress).anyTimes();
-        expect(inetAddress.getHostAddress()).andReturn("13.224.126.43").anyTimes(); // hooks.chime.aws IP
-        replayAll();
 
         DestinationHttpClient httpClient = new DestinationHttpClient();
         httpClient.setHttpClient(mockHttpClient);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**Woring In Progress**
 - Block reserved IP addresses from the list: https://en.wikipedia.org/wiki/Reserved_IP_addresses to be used as the notification destinations of alerts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
