### PR TITLE
Change release workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,10 +1,12 @@
 name: Release workflow
 # This workflow is triggered on creating tags to master or a opendistro release branch
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
-
+    branches:
+      - "release-workflow-patch"
 jobs:
   build:
     strategy:
@@ -44,65 +46,79 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts to S3
         run: |
-          s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp alerting-artifacts/*.zip $s3_path/elasticsearch-plugins/opendistro-alerting/
-          aws s3 cp alerting-artifacts/*.deb $s3_path/debs/opendistro-alerting/
-          aws s3 cp alerting-artifacts/*.rpm $s3_path/rpms/opendistro-alerting/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
+          zip=`ls alerting-artifacts/*.zip`
+          rpm=`ls alerting-artifacts/*.rpm`
+          deb=`ls alerting-artifacts/*.deb`
 
-      - name: Create Github Draft Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ env.TAG_VERSION }}
-          draft: true
-          prerelease: false
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
 
-      # Upload the release with .zip as asset
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: alerting.zip
-          asset_path: alerting-artifacts_zip
-          asset_content_type: application/zip
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-plugins/alerting/"
 
-      # Upload the release with .rpm as asset
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: alerting.rpm
-          asset_path: alerting-artifacts_rpm
-          asset_content_type: application/zip
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
 
-      # Upload the release with .deb as asset
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: alerting.deb
-          asset_path: alerting-artifacts_deb
-          asset_content_type: application/zip
+          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
 
-      - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: alerting-plugin
-          path: alerting-artifacts
+          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
+
+      # - name: Create Github Draft Release
+      #   id: create_release
+      #   uses: actions/create-release@v1.0.0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: Release ${{ env.TAG_VERSION }}
+      #     draft: true
+      #     prerelease: false
+
+      # # Upload the release with .zip as asset
+      # - name: Upload Release Asset
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_name: alerting.zip
+      #     asset_path: alerting-artifacts_zip
+      #     asset_content_type: application/zip
+
+      # # Upload the release with .rpm as asset
+      # - name: Upload Release Asset
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_name: alerting.rpm
+      #     asset_path: alerting-artifacts_rpm
+      #     asset_content_type: application/zip
+
+      # # Upload the release with .deb as asset
+      # - name: Upload Release Asset
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_name: alerting.deb
+      #     asset_path: alerting-artifacts_deb
+      #     asset_content_type: application/zip
+
+      # - name: Upload Workflow Artifacts
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: alerting-plugin
+      #     path: alerting-artifacts

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -71,52 +71,52 @@ jobs:
           echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
           aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 
-      # - name: Create Github Draft Release
-      #   id: create_release
-      #   uses: actions/create-release@v1.0.0
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: Release ${{ env.TAG_VERSION }}
-      #     draft: true
-      #     prerelease: false
+      - name: Create Github Draft Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ env.TAG_VERSION }}
+          draft: true
+          prerelease: false
 
-      # # Upload the release with .zip as asset
-      # - name: Upload Release Asset
-      #   uses: actions/upload-release-asset@v1.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_name: alerting.zip
-      #     asset_path: alerting-artifacts_zip
-      #     asset_content_type: application/zip
+      # Upload the release with .zip as asset
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: alerting.zip
+          asset_path: alerting-artifacts_zip
+          asset_content_type: application/zip
 
-      # # Upload the release with .rpm as asset
-      # - name: Upload Release Asset
-      #   uses: actions/upload-release-asset@v1.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_name: alerting.rpm
-      #     asset_path: alerting-artifacts_rpm
-      #     asset_content_type: application/zip
+      # Upload the release with .rpm as asset
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: alerting.rpm
+          asset_path: alerting-artifacts_rpm
+          asset_content_type: application/zip
 
-      # # Upload the release with .deb as asset
-      # - name: Upload Release Asset
-      #   uses: actions/upload-release-asset@v1.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_name: alerting.deb
-      #     asset_path: alerting-artifacts_deb
-      #     asset_content_type: application/zip
+      # Upload the release with .deb as asset
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: alerting.deb
+          asset_path: alerting-artifacts_deb
+          asset_content_type: application/zip
 
-      # - name: Upload Workflow Artifacts
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: alerting-plugin
-      #     path: alerting-artifacts
+      - name: Upload Workflow Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: alerting-plugin
+          path: alerting-artifacts

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,12 +1,10 @@
 name: Release workflow
 # This workflow is triggered on creating tags to master or a opendistro release branch
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com.

*Test Results*
https://github.com/gaiksaya/alerting/runs/1672094597?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
