### PR TITLE
Update to cron-utils:9.1.3 and update release notes for version 1.13.0.0

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,7 +1,7 @@
 ** Apache Commons Codec 1.10; version 1.10 -- http://commons.apache.org/proper/commons-codec/
 ** Apache Commons Logging; version 1.1.3 -- https://commons.apache.org/proper/commons-logging/
 ** Apache-HttpComponents-HttpCore; version 4.4.5 -- https://hc.apache.org/httpcomponents-core-ga/
-** cron-utils; version 7.0.5 -- https://github.com/jmrozanec/cron-utils/tree/7.0.5
+** cron-utils; version 9.1.3 -- https://github.com/jmrozanec/cron-utils/tree/9.1.3
 ** EasyMock; version 4.0.1 -- https://mvnrepository.com/artifact/org.easymock/easymock/4.0.1
 ** elasticsearch 6.5.4; version 6.5.4 -- https://github.com/elastic/elasticsearch/tree/v6.5.4
 ** Jackson Core; version 2.8.10 -- https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.10

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
-    compile "com.cronutils:cron-utils:7.0.5"
+    compile "com.cronutils:cron-utils:9.1.3"
     compile "org.elasticsearch.client:elasticsearch-rest-client:${es_version}"
     compile 'com.google.googlejavaformat:google-java-format:1.3'
     compile "com.amazon.opendistroforelasticsearch:common-utils:${opendistroVersion}.0"

--- a/release-notes/opendistro-for-elasticsearch-alerting.release-notes-1.13.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-alerting.release-notes-1.13.0.0.md
@@ -2,11 +2,16 @@
 
 Compatible with Elasticsearch 7.10.2
 
+### Bug Fixes
+* Move user instantiation to doExecute [#343](https://github.com/opendistro-for-elasticsearch/alerting/pull/343)
+
 ### Infrastructure
 * Rename plugin for more consistent naming convention [#339](https://github.com/opendistro-for-elasticsearch/alerting/pull/339)
+* Change release workflow to use new staging bucket for artifacts [#334](https://github.com/opendistro-for-elasticsearch/alerting/pull/339)
 
 ### Documentation
 * Add RFC for Document-Level Alerting [#327](https://github.com/opendistro-for-elasticsearch/alerting/pull/327)
 
 ### Maintenance
 * Adds support for Elasticsearch 7.10.2 [#340](https://github.com/opendistro-for-elasticsearch/alerting/pull/340)
+* Update cron-utils to version 9.1.3 [#344](https://github.com/opendistro-for-elasticsearch/alerting/pull/344)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updating cron-utils dependency to 9.1.3
* Updating release notes but doing it in place and keeping version 1.13.0.0 since the tag needs to be recut anyway to trigger the updated workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
