### PR TITLE
Refactor Trigger to be an interface and update Monitor

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -43,6 +43,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.resthandler.RestSched
 import com.amazon.opendistroforelasticsearch.alerting.core.schedule.JobScheduler
 import com.amazon.opendistroforelasticsearch.alerting.core.settings.ScheduledJobSettings
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestAcknowledgeAlertAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestDeleteDestinationAction
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestDeleteEmailAccountAction
@@ -117,7 +118,7 @@ import java.util.function.Supplier
 /**
  * Entry point of the OpenDistro for Elasticsearch alerting plugin
  * This class initializes the [RestGetMonitorAction], [RestDeleteMonitorAction], [RestIndexMonitorAction] rest handlers.
- * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY] to the
+ * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY], [TraditionalTrigger.XCONTENT_REGISTRY] to the
  * [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
  */
 internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, ReloadablePlugin, Plugin() {
@@ -200,7 +201,7 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     }
 
     override fun getNamedXContent(): List<NamedXContentRegistry.Entry> {
-        return listOf(Monitor.XCONTENT_REGISTRY, SearchInput.XCONTENT_REGISTRY)
+        return listOf(Monitor.XCONTENT_REGISTRY, SearchInput.XCONTENT_REGISTRY, TraditionalTrigger.XCONTENT_REGISTRY)
     }
 
     override fun createComponents(

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingPlugin.kt
@@ -42,6 +42,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.core.resthandler.RestScheduledJobStatsHandler
 import com.amazon.opendistroforelasticsearch.alerting.core.schedule.JobScheduler
 import com.amazon.opendistroforelasticsearch.alerting.core.settings.ScheduledJobSettings
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.resthandler.RestAcknowledgeAlertAction
@@ -118,8 +119,8 @@ import java.util.function.Supplier
 /**
  * Entry point of the OpenDistro for Elasticsearch alerting plugin
  * This class initializes the [RestGetMonitorAction], [RestDeleteMonitorAction], [RestIndexMonitorAction] rest handlers.
- * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY], [TraditionalTrigger.XCONTENT_REGISTRY] to the
- * [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
+ * It also adds [Monitor.XCONTENT_REGISTRY], [SearchInput.XCONTENT_REGISTRY], [TraditionalTrigger.XCONTENT_REGISTRY],
+ * [AggregationTrigger.XCONTENT_REGISTRY] to the [NamedXContentRegistry] so that we are able to deserialize the custom named objects.
  */
 internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, ReloadablePlugin, Plugin() {
     override fun getContextWhitelists(): Map<ScriptContext<*>, List<Whitelist>> {
@@ -201,7 +202,11 @@ internal class AlertingPlugin : PainlessExtension, ActionPlugin, ScriptPlugin, R
     }
 
     override fun getNamedXContent(): List<NamedXContentRegistry.Entry> {
-        return listOf(Monitor.XCONTENT_REGISTRY, SearchInput.XCONTENT_REGISTRY, TraditionalTrigger.XCONTENT_REGISTRY)
+        return listOf(
+            Monitor.XCONTENT_REGISTRY,
+            SearchInput.XCONTENT_REGISTRY,
+            TraditionalTrigger.XCONTENT_REGISTRY,
+            AggregationTrigger.XCONTENT_REGISTRY)
     }
 
     override fun createComponents(

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -26,6 +26,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.AlertingConfigAccessor
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.MonitorRunResult
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.TriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Companion.MESSAGE
@@ -272,8 +273,8 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
         val triggerResults = mutableMapOf<String, TriggerRunResult>()
         for (trigger in monitor.triggers) {
             val currentAlert = currentAlerts[trigger]
-            val triggerCtx = TriggerExecutionContext(monitor, trigger, monitorResult, currentAlert)
-            val triggerResult = triggerService.runTrigger(monitor, trigger, triggerCtx)
+            val triggerCtx = TriggerExecutionContext(monitor, trigger as TraditionalTrigger, monitorResult, currentAlert)
+            val triggerResult = triggerService.runTraditionalTrigger(monitor, trigger, triggerCtx)
             triggerResults[trigger.id] = triggerResult
 
             if (triggerService.isTriggerActionable(triggerCtx, triggerResult)) {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -295,7 +295,12 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
         return monitorResult.copy(triggerResults = triggerResults)
     }
 
-    suspend fun runAggregationMonitor(monitor: Monitor, periodStart: Instant, periodEnd: Instant, dryrun: Boolean = false): MonitorRunResult {
+    suspend fun runAggregationMonitor(
+        monitor: Monitor,
+        periodStart: Instant,
+        periodEnd: Instant,
+        dryrun: Boolean = false
+    ): MonitorRunResult {
         val roles = getRolesForMonitor(monitor)
         logger.debug("Running monitor: ${monitor.name} with roles: $roles Thread: ${Thread.currentThread().name}")
 
@@ -305,31 +310,7 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
 
         // TODO: Should we use MonitorRunResult for both Monitor types or create an AggregationMonitorRunResult
         //  to store InternalComposite instead of Map<String, Any>?
-        /*
-         * Iterating over the Map even in the aggregation case should be fine (we'll be passing the Map of the individual buckets during
-         * the Painless script execution of the Trigger anyway).
-         *
-         * One possible issue is that the aggregation name of the composite aggregation can be user defined and we'll need that value to
-         * ensure we access the correct aggregation in the Map (this could potentially be retrieved from the SearchSourceBuilder, assuming
-         * we validate and only allow a single composite aggregation in the query, which seems reasonable).
-         * Ex.
-         * {
-         *   ...
-         *   "aggregations": {
-         *     "my_buckets": { <-------- This can be called anything
-         *       "after_key": {
-         *         "date": 1494201600000,
-         *         "product": "rocky"
-         *       },
-         *       "buckets": [
-         *         ...
-         *       ]
-         *       ...
-         *     }
-         *   }
-         * }
-         */
-         var monitorResult = MonitorRunResult(monitor.name, periodStart, periodEnd)
+        var monitorResult = MonitorRunResult(monitor.name, periodStart, periodEnd)
         val currentAlerts = try {
             alertIndices.createOrUpdateAlertIndex()
             alertIndices.createOrUpdateInitialHistoryIndex()

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/TriggerService.kt
@@ -17,7 +17,7 @@ package com.amazon.opendistroforelasticsearch.alerting
 
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
-import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.TriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.script.TriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TriggerScript
@@ -36,7 +36,7 @@ class TriggerService(val client: Client, val scriptService: ScriptService) {
         return result.triggered && !suppress
     }
 
-    fun runTrigger(monitor: Monitor, trigger: Trigger, ctx: TriggerExecutionContext): TriggerRunResult {
+    fun runTraditionalTrigger(monitor: Monitor, trigger: TraditionalTrigger, ctx: TriggerExecutionContext): TriggerRunResult {
         return try {
             val triggered = scriptService.compile(trigger.condition, TriggerScript.CONTEXT)
                 .newInstance(trigger.condition.params)

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTrigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTrigger.kt
@@ -1,0 +1,133 @@
+/*
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting.model
+
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ID_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.NAME_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.action.Action
+import org.elasticsearch.common.CheckedFunction
+import org.elasticsearch.common.ParseField
+import org.elasticsearch.common.UUIDs
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParser.Token
+import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import java.io.IOException
+
+/**
+ * A multi-alert Trigger available with Aggregation Monitors that filters aggregation buckets via a pipeline
+ * aggregator.
+ */
+data class AggregationTrigger(
+    override val id: String = UUIDs.base64UUID(),
+    override val name: String,
+    override val severity: String,
+    override val actions: List<Action>
+    // TODO: Add the remaining member variables based on integrated with Trigger pipeline aggregator
+) : Trigger {
+
+    // TODO: Once class is full implemented add tests to the following suites:
+    //  - WriteableTests
+    //  - XContentTests
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput): this(
+        sin.readString(), // id
+        sin.readString(), // name
+        sin.readString(), // severity
+        sin.readList(::Action) // actions
+        // TODO: Add remainder of inputs after integration
+    )
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .startObject(AGGREGATION_TRIGGER_FIELD)
+            .field(ID_FIELD, id)
+            .field(NAME_FIELD, name)
+            .field(SEVERITY_FIELD, severity)
+            .field(ACTIONS_FIELD, actions.toTypedArray())
+            // TODO: Add remainder of contents after integration
+            .endObject()
+            .endObject()
+        return builder
+    }
+
+    override fun name(): String {
+        return AGGREGATION_TRIGGER_FIELD
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeString(name)
+        out.writeString(severity)
+        out.writeCollection(actions)
+        // TODO: Add remainder of outputs after integration
+    }
+
+    companion object {
+        const val AGGREGATION_TRIGGER_FIELD = "aggregation_trigger"
+
+        val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(Trigger::class.java, ParseField(AGGREGATION_TRIGGER_FIELD),
+            CheckedFunction { parseInner(it) })
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun parseInner(xcp: XContentParser): AggregationTrigger {
+            var id = UUIDs.base64UUID() // assign a default triggerId if one is not specified
+            lateinit var name: String
+            lateinit var severity: String
+            val actions: MutableList<Action> = mutableListOf()
+            ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+
+            while (xcp.nextToken() != Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+
+                xcp.nextToken()
+                when (fieldName) {
+                    ID_FIELD -> id = xcp.text()
+                    NAME_FIELD -> name = xcp.text()
+                    SEVERITY_FIELD -> severity = xcp.text()
+                    ACTIONS_FIELD -> {
+                        ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != Token.END_ARRAY) {
+                            actions.add(Action.parse(xcp))
+                        }
+                    }
+                    // TODO: Add remainder of field to parse after integration
+                }
+            }
+
+            return AggregationTrigger(
+                id = requireNotNull(id) { "Trigger id is null." },
+                name = requireNotNull(name) { "Trigger name is null" },
+                severity = requireNotNull(severity) { "Trigger severity is null" },
+                actions = requireNotNull(actions) { "Trigger actions are null" })
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): AggregationTrigger {
+            return AggregationTrigger(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Monitor.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Monitor.kt
@@ -21,7 +21,6 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.Schedule
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.instant
-import com.amazon.opendistroforelasticsearch.alerting.elasticapi.optionalStringList
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.optionalTimeField
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.optionalUserField
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings.Companion.MONITOR_MAX_INPUTS
@@ -43,6 +42,7 @@ import org.elasticsearch.common.xcontent.XContentParser.Token
 import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import java.io.IOException
 import java.time.Instant
+import java.util.Locale
 
 /**
  * A value object that represents a Monitor. Monitors are used to periodically execute a source query and check the
@@ -56,13 +56,12 @@ data class Monitor(
     override val schedule: Schedule,
     override val lastUpdateTime: Instant,
     override val enabledTime: Instant?,
+    // TODO: Check how this behaves during rolling upgrade/multi-version cluster
+    //  Can read/write and parsing break if it's done from an old -> new version of the plugin?
     val monitorType: MonitorType,
     val user: User?,
     val schemaVersion: Int = NO_SCHEMA_VERSION,
     val inputs: List<Input>,
-    // TODO: Check how this behaves during rolling upgrade/multi-version cluster
-    //  Can read/write and parsing break if it's done from an old -> new version of the plugin?
-    val groupByFields: List<String>?,
     val triggers: List<Trigger>,
     val uiMetadata: Map<String, Any>
 ) : ScheduledJob {
@@ -74,6 +73,7 @@ data class Monitor(
         val triggerIds = mutableSetOf<String>()
         triggers.forEach { trigger ->
             require(triggerIds.add(trigger.id)) { "Duplicate trigger id: ${trigger.id}. Trigger ids must be unique." }
+            // TODO: Verify Trigger type based on Monitor type
         }
         if (enabled) {
             requireNotNull(enabledTime)
@@ -83,7 +83,7 @@ data class Monitor(
         require(inputs.size <= MONITOR_MAX_INPUTS) { "Monitors can only have $MONITOR_MAX_INPUTS search input." }
         require(triggers.size <= MONITOR_MAX_TRIGGERS) { "Monitors can only support up to $MONITOR_MAX_TRIGGERS triggers." }
         if (this.isAggregationMonitor()) {
-            // TODO: Add a verification for groupByFields and on Inputs when there are groupByFields
+            // TODO: Add a verification on Inputs when there is an Aggregation Monitor
         }
     }
 
@@ -102,7 +102,6 @@ data class Monitor(
         } else null,
         schemaVersion = sin.readInt(),
         inputs = sin.readList(::SearchInput),
-        groupByFields = sin.readOptionalStringList(),
         triggers = sin.readList(::Trigger),
         uiMetadata = suppressWarning(sin.readMap())
     )
@@ -139,7 +138,6 @@ data class Monitor(
             .optionalTimeField(ENABLED_TIME_FIELD, enabledTime)
             .field(SCHEDULE_FIELD, schedule)
             .field(INPUTS_FIELD, inputs.toTypedArray())
-            .optionalStringList(GROUP_BY_FIELD, groupByFields)
             .field(TRIGGERS_FIELD, triggers.toTypedArray())
             .optionalTimeField(LAST_UPDATE_TIME_FIELD, lastUpdateTime)
         if (uiMetadata.isNotEmpty()) builder.field(UI_METADATA_FIELD, uiMetadata)
@@ -168,7 +166,6 @@ data class Monitor(
         user?.writeTo(out)
         out.writeInt(schemaVersion)
         out.writeCollection(inputs)
-        out.writeOptionalStringCollection(groupByFields)
         out.writeCollection(triggers)
         out.writeMap(uiMetadata)
     }
@@ -186,7 +183,6 @@ data class Monitor(
         const val NO_ID = ""
         const val NO_VERSION = 1L
         const val INPUTS_FIELD = "inputs"
-        const val GROUP_BY_FIELD = "group_by_fields"
         const val LAST_UPDATE_TIME_FIELD = "last_update_time"
         const val UI_METADATA_FIELD = "ui_metadata"
         const val ENABLED_TIME_FIELD = "enabled_time"
@@ -203,7 +199,7 @@ data class Monitor(
         fun parse(xcp: XContentParser, id: String = NO_ID, version: Long = NO_VERSION): Monitor {
             lateinit var name: String
             // Default to TRADITIONAL_MONITOR to cover Monitors that existed before the addition of MonitorType
-            var monitorType: MonitorType = MonitorType.TRADITIONAL_MONITOR
+            var monitorType: String = MonitorType.TRADITIONAL_MONITOR.toString()
             var user: User? = null
             lateinit var schedule: Schedule
             var lastUpdateTime: Instant? = null
@@ -213,7 +209,6 @@ data class Monitor(
             var schemaVersion = NO_SCHEMA_VERSION
             val triggers: MutableList<Trigger> = mutableListOf()
             val inputs: MutableList<Input> = mutableListOf()
-            var groupByFields: MutableList<String>? = mutableListOf()
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != Token.END_OBJECT) {
@@ -223,7 +218,13 @@ data class Monitor(
                 when (fieldName) {
                     SCHEMA_VERSION_FIELD -> schemaVersion = xcp.intValue()
                     NAME_FIELD -> name = xcp.text()
-                    MONITOR_TYPE_FIELD -> monitorType = MonitorType.valueOf(xcp.text())
+                    MONITOR_TYPE_FIELD -> {
+                        monitorType = xcp.text()
+                        val allowedTypes = MonitorType.values().map { it.value }
+                        if (!allowedTypes.contains(monitorType)) {
+                            throw IllegalStateException("Monitor type should be one of $allowedTypes")
+                        }
+                    }
                     USER_FIELD -> user = if (xcp.currentToken() == Token.VALUE_NULL) null else User.parse(xcp)
                     ENABLED_FIELD -> enabled = xcp.booleanValue()
                     SCHEDULE_FIELD -> schedule = Schedule.parse(xcp)
@@ -231,16 +232,6 @@ data class Monitor(
                         ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
                         while (xcp.nextToken() != Token.END_ARRAY) {
                             inputs.add(Input.parse(xcp))
-                        }
-                    }
-                    GROUP_BY_FIELD -> {
-                        if (xcp.currentToken() == Token.VALUE_NULL) {
-                            groupByFields = null
-                        } else {
-                            ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
-                            while (xcp.nextToken() != Token.END_ARRAY) {
-                                groupByFields?.add(xcp.text())
-                            }
                         }
                     }
                     TRIGGERS_FIELD -> {
@@ -270,11 +261,10 @@ data class Monitor(
                     requireNotNull(schedule) { "Monitor schedule is null" },
                     lastUpdateTime ?: Instant.now(),
                     enabledTime,
-                    monitorType,
+                    MonitorType.valueOf(monitorType.toUpperCase(Locale.ROOT)),
                     user,
                     schemaVersion,
                     inputs.toList(),
-                    groupByFields?.toList(),
                     triggers.toList(),
                     uiMetadata)
         }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/TraditionalTrigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/TraditionalTrigger.kt
@@ -1,3 +1,18 @@
+/*
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.alerting.model
 
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ACTIONS_FIELD
@@ -16,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentParser.Token
 import org.elasticsearch.common.xcontent.XContentParserUtils
+import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.elasticsearch.script.Script
 import java.io.IOException
 
@@ -147,7 +163,7 @@ data class TraditionalTrigger(
                         xcp.nextToken()
                     }
                     ACTIONS_FIELD -> {
-                        XContentParserUtils.ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                        ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
                         while (xcp.nextToken() != Token.END_ARRAY) {
                             actions.add(Action.parse(xcp))
                         }
@@ -166,7 +182,7 @@ data class TraditionalTrigger(
 
         @JvmStatic
         @Throws(IOException::class)
-        fun readFrom(sin: StreamInput): Trigger {
+        fun readFrom(sin: StreamInput): TraditionalTrigger {
             return TraditionalTrigger(sin)
         }
     }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/TraditionalTrigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/TraditionalTrigger.kt
@@ -1,0 +1,173 @@
+package com.amazon.opendistroforelasticsearch.alerting.model
+
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ID_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.NAME_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import com.amazon.opendistroforelasticsearch.alerting.model.action.Action
+import org.elasticsearch.common.CheckedFunction
+import org.elasticsearch.common.ParseField
+import org.elasticsearch.common.UUIDs
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParser.Token
+import org.elasticsearch.common.xcontent.XContentParserUtils
+import org.elasticsearch.script.Script
+import java.io.IOException
+
+/**
+ * A single-alert Trigger that uses Painless scripts which execute on the response of the Monitor input query to define
+ * alerting conditions.
+ */
+data class TraditionalTrigger(
+    override val id: String = UUIDs.base64UUID(),
+    override val name: String,
+    override val severity: String,
+    override val actions: List<Action>,
+    val condition: Script
+) : Trigger {
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput): this(
+        sin.readString(), // id
+        sin.readString(), // name
+        sin.readString(), // severity
+        sin.readList(::Action), // actions
+        Script(sin) // condition
+    )
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .startObject(TRADITIONAL_TRIGGER_FIELD)
+            .field(ID_FIELD, id)
+            .field(NAME_FIELD, name)
+            .field(SEVERITY_FIELD, severity)
+            .startObject(CONDITION_FIELD)
+            .field(SCRIPT_FIELD, condition)
+            .endObject()
+            .field(ACTIONS_FIELD, actions.toTypedArray())
+            .endObject()
+            .endObject()
+        return builder
+    }
+
+    override fun name(): String {
+        return TRADITIONAL_TRIGGER_FIELD
+    }
+
+    /** Returns a representation of the trigger suitable for passing into painless and mustache scripts. */
+    fun asTemplateArg(): Map<String, Any> {
+        return mapOf(ID_FIELD to id, NAME_FIELD to name, SEVERITY_FIELD to severity,
+            ACTIONS_FIELD to actions.map { it.asTemplateArg() })
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeString(name)
+        out.writeString(severity)
+        out.writeCollection(actions)
+        condition.writeTo(out)
+    }
+
+    companion object {
+        const val TRADITIONAL_TRIGGER_FIELD = "traditional_trigger"
+        const val CONDITION_FIELD = "condition"
+        const val SCRIPT_FIELD = "script"
+
+        val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(Trigger::class.java, ParseField(TRADITIONAL_TRIGGER_FIELD),
+            CheckedFunction { parseInner(it) })
+
+        /**
+         * This parse method needs to account for both the old and new Trigger format.
+         * In the old format, only one Trigger existed (which is now TraditionalTrigger) and it was
+         * not a named object.
+         *
+         * The parse() method in the Trigger interface needs to consume the outer START_OBJECT to be able
+         * to infer whether it is dealing with the old or new Trigger format. This means that the currentToken at
+         * the time this parseInner method is called could differ based on which format is being dealt with.
+         *
+         * Old Format
+         * ----------
+         * {
+         *   "id": ...,
+         *    ^
+         *    Current token starts here
+         *   "name" ...,
+         *   ...
+         * }
+         *
+         * New Format
+         * ----------
+         * {
+         *   "traditional_trigger": {
+         *     "id": ...,           ^ Current token starts here
+         *     "name": ...,
+         *     ...
+         *   }
+         * }
+         *
+         * It isn't typically conventional but this parse method will account for both START_OBJECT
+         * and FIELD_NAME as the starting token to cover both cases.
+         */
+        @JvmStatic @Throws(IOException::class)
+        fun parseInner(xcp: XContentParser): TraditionalTrigger {
+            var id = UUIDs.base64UUID() // assign a default triggerId if one is not specified
+            lateinit var name: String
+            lateinit var severity: String
+            lateinit var condition: Script
+            val actions: MutableList<Action> = mutableListOf()
+
+            if (xcp.currentToken() != Token.START_OBJECT && xcp.currentToken() != Token.FIELD_NAME) {
+                XContentParserUtils.throwUnknownToken(xcp.currentToken(), xcp.tokenLocation)
+            }
+
+            // If the parser began on START_OBJECT, move to the next token so that the while loop enters on
+            // the fieldName (or END_OBJECT if it's empty).
+            if (xcp.currentToken() == Token.START_OBJECT) xcp.nextToken()
+
+            while (xcp.currentToken() != Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+
+                xcp.nextToken()
+                when (fieldName) {
+                    ID_FIELD -> id = xcp.text()
+                    NAME_FIELD -> name = xcp.text()
+                    SEVERITY_FIELD -> severity = xcp.text()
+                    CONDITION_FIELD -> {
+                        xcp.nextToken()
+                        condition = Script.parse(xcp)
+                        require(condition.lang == Script.DEFAULT_SCRIPT_LANG) {
+                            "Invalid script language. Allowed languages are [${Script.DEFAULT_SCRIPT_LANG}]"
+                        }
+                        xcp.nextToken()
+                    }
+                    ACTIONS_FIELD -> {
+                        XContentParserUtils.ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
+                        while (xcp.nextToken() != Token.END_ARRAY) {
+                            actions.add(Action.parse(xcp))
+                        }
+                    }
+                }
+                xcp.nextToken()
+            }
+
+            return TraditionalTrigger(
+                name = requireNotNull(name) { "Trigger name is null" },
+                severity = requireNotNull(severity) { "Trigger severity is null" },
+                condition = requireNotNull(condition) { "Trigger is null" },
+                actions = requireNotNull(actions) { "Trigger actions are null" },
+                id = requireNotNull(id) { "Trigger id is null." })
+        }
+
+        @JvmStatic
+        @Throws(IOException::class)
+        fun readFrom(sin: StreamInput): Trigger {
+            return TraditionalTrigger(sin)
+        }
+    }
+}

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Trigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Trigger.kt
@@ -15,117 +15,77 @@
 
 package com.amazon.opendistroforelasticsearch.alerting.model
 
+import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob.Companion.SCHEDULED_JOBS_INDEX
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action
-import org.elasticsearch.common.UUIDs
 import org.elasticsearch.common.io.stream.StreamInput
-import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.io.stream.Writeable
-import org.elasticsearch.common.xcontent.ToXContent
-import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.ToXContentObject
 import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentParser.Token
 import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
-import org.elasticsearch.script.Script
 import java.io.IOException
 
-data class Trigger(
-    val name: String,
-    val severity: String,
-    val condition: Script,
-    val actions: List<Action>,
-    val id: String = UUIDs.base64UUID()
-) : Writeable, ToXContent {
+interface Trigger : Writeable, ToXContentObject {
 
-    @Throws(IOException::class)
-    constructor(sin: StreamInput): this(
-            sin.readString(), // name
-            sin.readString(), // severity
-            Script(sin), // condition
-            sin.readList(::Action), // actions
-            sin.readString() // id
-    )
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        builder.startObject()
-                .field(ID_FIELD, id)
-                .field(NAME_FIELD, name)
-                .field(SEVERITY_FIELD, severity)
-                .startObject(CONDITION_FIELD)
-                .field(SCRIPT_FIELD, condition)
-                .endObject()
-                .field(ACTIONS_FIELD, actions.toTypedArray())
-                .endObject()
-        return builder
-    }
+    enum class Type(val value: String) {
+        TRADITIONAL_TRIGGER(TraditionalTrigger.TRADITIONAL_TRIGGER_FIELD),
+        AGGREGATION_TRIGGER("change_this");
 
-    /** Returns a representation of the trigger suitable for passing into painless and mustache scripts. */
-    fun asTemplateArg(): Map<String, Any> {
-        return mapOf(ID_FIELD to id, NAME_FIELD to name, SEVERITY_FIELD to severity,
-                ACTIONS_FIELD to actions.map { it.asTemplateArg() })
-    }
-
-    @Throws(IOException::class)
-    override fun writeTo(out: StreamOutput) {
-        out.writeString(name)
-        out.writeString(severity)
-        condition.writeTo(out)
-        out.writeCollection(actions)
-        out.writeString(id)
+        override fun toString(): String {
+            return value
+        }
     }
 
     companion object {
         const val ID_FIELD = "id"
         const val NAME_FIELD = "name"
         const val SEVERITY_FIELD = "severity"
-        const val CONDITION_FIELD = "condition"
         const val ACTIONS_FIELD = "actions"
-        const val SCRIPT_FIELD = "script"
 
-        @JvmStatic @Throws(IOException::class)
+        @Throws(IOException::class)
         fun parse(xcp: XContentParser): Trigger {
-            var id = UUIDs.base64UUID() // assign a default triggerId if one is not specified
-            lateinit var name: String
-            lateinit var severity: String
-            lateinit var condition: Script
-            val actions: MutableList<Action> = mutableListOf()
+            val trigger: Trigger
+
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
-
-            while (xcp.nextToken() != Token.END_OBJECT) {
-                val fieldName = xcp.currentName()
-
-                xcp.nextToken()
-                when (fieldName) {
-                    ID_FIELD -> id = xcp.text()
-                    NAME_FIELD -> name = xcp.text()
-                    SEVERITY_FIELD -> severity = xcp.text()
-                    CONDITION_FIELD -> {
-                        xcp.nextToken()
-                        condition = Script.parse(xcp)
-                        require(condition.lang == Script.DEFAULT_SCRIPT_LANG) {
-                            "Invalid script language. Allowed languages are [${Script.DEFAULT_SCRIPT_LANG}]"
-                        }
-                        xcp.nextToken()
-                    }
-                    ACTIONS_FIELD -> {
-                        ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
-                        while (xcp.nextToken() != Token.END_ARRAY) {
-                            actions.add(Action.parse(xcp))
-                        }
-                    }
-                }
+            ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp)
+            val triggerTypeNames = Type.values().map { it.toString() }
+            if (triggerTypeNames.contains(xcp.currentName())) {
+                ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp)
+                trigger = xcp.namedObject(Trigger::class.java, xcp.currentName(), null)
+                ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp)
+            } else {
+                // Infer the old Trigger (now called TraditionalTrigger) when it is not defined as a named
+                // object to remain backwards compatible when parsing the old format
+                trigger = TraditionalTrigger.parseInner(xcp)
+                ensureExpectedToken(Token.END_OBJECT, xcp.currentToken(), xcp)
             }
-
-            return Trigger(
-                    name = requireNotNull(name) { "Trigger name is null" },
-                    severity = requireNotNull(severity) { "Trigger severity is null" },
-                    condition = requireNotNull(condition) { "Trigger is null" },
-                    actions = requireNotNull(actions) { "Trigger actions are null" },
-                    id = requireNotNull(id) { "Trigger id is null." })
+            return trigger
         }
 
         @JvmStatic
         @Throws(IOException::class)
         fun readFrom(sin: StreamInput): Trigger {
-            return Trigger(sin)
+            val type = sin.readEnum(Trigger.Type::class.java)
+            return if (type == Type.TRADITIONAL_TRIGGER) {
+                TraditionalTrigger(sin)
+            } else {
+                // TODO: return AggregationTrigger(sin)
+                TraditionalTrigger(sin)
+            }
         }
     }
+
+    /** The id of the Trigger in the [SCHEDULED_JOBS_INDEX] */
+    val id: String
+
+    /** The name of the Trigger */
+    val name: String
+
+    /** The severity of the Trigger, used to classify the subsequent Alert */
+    val severity: String
+
+    /** The actions executed if the Trigger condition evaluates to true */
+    val actions: List<Action>
+
+    fun name(): String
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Trigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Trigger.kt
@@ -29,7 +29,7 @@ interface Trigger : Writeable, ToXContentObject {
 
     enum class Type(val value: String) {
         TRADITIONAL_TRIGGER(TraditionalTrigger.TRADITIONAL_TRIGGER_FIELD),
-        AGGREGATION_TRIGGER("change_this");
+        AGGREGATION_TRIGGER(AggregationTrigger.AGGREGATION_TRIGGER_FIELD);
 
         override fun toString(): String {
             return value
@@ -65,12 +65,12 @@ interface Trigger : Writeable, ToXContentObject {
         @JvmStatic
         @Throws(IOException::class)
         fun readFrom(sin: StreamInput): Trigger {
-            val type = sin.readEnum(Trigger.Type::class.java)
-            return if (type == Type.TRADITIONAL_TRIGGER) {
-                TraditionalTrigger(sin)
-            } else {
-                // TODO: return AggregationTrigger(sin)
-                TraditionalTrigger(sin)
+            return when (val type = sin.readEnum(Trigger.Type::class.java)) {
+                Type.TRADITIONAL_TRIGGER -> TraditionalTrigger(sin)
+                Type.AGGREGATION_TRIGGER -> AggregationTrigger(sin)
+                // This shouldn't be reachable but ensuring exhaustiveness as Kotlin warns
+                // enum can be null in Java
+                else -> throw IllegalStateException("Unexpected input [$type] when reading Trigger")
             }
         }
     }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/TriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/TriggerExecutionContext.kt
@@ -18,12 +18,12 @@ package com.amazon.opendistroforelasticsearch.alerting.script
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.MonitorRunResult
-import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import java.time.Instant
 
 data class TriggerExecutionContext(
     val monitor: Monitor,
-    val trigger: Trigger,
+    val trigger: TraditionalTrigger,
     val results: List<Map<String, Any>>,
     val periodStart: Instant,
     val periodEnd: Instant,
@@ -31,7 +31,7 @@ data class TriggerExecutionContext(
     val error: Exception? = null
 ) {
 
-    constructor(monitor: Monitor, trigger: Trigger, monitorRunResult: MonitorRunResult, alert: Alert? = null):
+    constructor(monitor: Monitor, trigger: TraditionalTrigger, monitorRunResult: MonitorRunResult, alert: Alert? = null):
             this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart,
             monitorRunResult.periodEnd, alert, monitorRunResult.scriptContextError(trigger))
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AlertingUtils.kt
@@ -120,4 +120,4 @@ fun <T : Any> checkUserFilterByPermissions(
     return true
 }
 
-fun Monitor.isAggregationMonitor(): Boolean = !this.groupByFields.isNullOrEmpty()
+fun Monitor.isAggregationMonitor(): Boolean = this.monitorType == Monitor.MonitorType.AGGREGATION_MONITOR

--- a/alerting/src/main/resources/com/amazon/opendistroforelasticsearch/alerting/com.amazon.opendistroforelasticsearch.alerting.txt
+++ b/alerting/src/main/resources/com/amazon/opendistroforelasticsearch/alerting/com.amazon.opendistroforelasticsearch.alerting.txt
@@ -14,7 +14,7 @@ class com.amazon.opendistroforelasticsearch.alerting.script.TriggerScript$Factor
 
 class com.amazon.opendistroforelasticsearch.alerting.script.TriggerExecutionContext {
     Monitor getMonitor()
-    Trigger getTrigger()
+    TraditionalTrigger getTrigger()
     List getResults()
     java.time.Instant getPeriodStart()
     java.time.Instant getPeriodEnd()
@@ -29,7 +29,7 @@ class com.amazon.opendistroforelasticsearch.alerting.model.Monitor {
     boolean getEnabled()
 }
 
-class com.amazon.opendistroforelasticsearch.alerting.model.Trigger {
+class com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger {
     String getId()
     String getName()
     String getSeverity()

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ADTestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ADTestHelpers.kt
@@ -502,9 +502,9 @@ fun randomADMonitor(
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     withMetadata: Boolean = false
 ): Monitor {
-    return Monitor(name = name, enabled = enabled, inputs = inputs, groupByFields = null, schedule = schedule, triggers = triggers,
-            enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
-            user = user, uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
+    return Monitor(name = name, monitorType = Monitor.MonitorType.TRADITIONAL_MONITOR, enabled = enabled, inputs = inputs,
+        schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
+        user = user, uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
 }
 
 fun randomADUser(backendRole: String = ESRestTestCase.randomAlphaOfLength(10)): User {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ADTestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/ADTestHelpers.kt
@@ -19,6 +19,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.IntervalSchedul
 import com.amazon.opendistroforelasticsearch.alerting.core.model.Schedule
 import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
 import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import org.elasticsearch.index.query.BoolQueryBuilder
@@ -479,12 +480,12 @@ fun maxAnomalyGradeSearchInput(
     return SearchInput(indices = listOf(adResultIndex), query = searchSourceBuilder)
 }
 
-fun adMonitorTrigger(): Trigger {
+fun adMonitorTrigger(): TraditionalTrigger {
     val triggerScript = """
             return ctx.results[0].aggregations.max_anomaly_grade.value != null && 
                    ctx.results[0].aggregations.max_anomaly_grade.value > 0.7
         """.trimIndent()
-    return randomTrigger(condition = Script(triggerScript))
+    return randomTraditionalTrigger(condition = Script(triggerScript))
 }
 
 fun adSearchInput(detectorId: String): SearchInput {
@@ -497,7 +498,7 @@ fun randomADMonitor(
     inputs: List<Input> = listOf(adSearchInput("test_detector_id")),
     schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
     enabled: Boolean = ESTestCase.randomBoolean(),
-    triggers: List<Trigger> = (1..ESTestCase.randomInt(10)).map { randomTrigger() },
+    triggers: List<Trigger> = (1..ESTestCase.randomInt(10)).map { randomTraditionalTrigger() },
     enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     withMetadata: Boolean = false

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.core.settings.ScheduledJobSettings
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.string
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
@@ -79,7 +80,8 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
             mutableListOf(
                 Monitor.XCONTENT_REGISTRY,
                 SearchInput.XCONTENT_REGISTRY,
-                TraditionalTrigger.XCONTENT_REGISTRY
+                TraditionalTrigger.XCONTENT_REGISTRY,
+                AggregationTrigger.XCONTENT_REGISTRY
             ) + SearchModule(Settings.EMPTY, false, emptyList()).namedXContents)
     }
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertingRestTestCase.kt
@@ -24,6 +24,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.settings.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.string
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Destination
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.EmailAccount
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.EmailGroup
@@ -74,9 +75,12 @@ abstract class AlertingRestTestCase : ODFERestTestCase() {
     val numberOfNodes = System.getProperty("cluster.number_of_nodes", "1")!!.toInt()
 
     override fun xContentRegistry(): NamedXContentRegistry {
-        return NamedXContentRegistry(mutableListOf(Monitor.XCONTENT_REGISTRY,
-                SearchInput.XCONTENT_REGISTRY) +
-                SearchModule(Settings.EMPTY, false, emptyList()).namedXContents)
+        return NamedXContentRegistry(
+            mutableListOf(
+                Monitor.XCONTENT_REGISTRY,
+                SearchInput.XCONTENT_REGISTRY,
+                TraditionalTrigger.XCONTENT_REGISTRY
+            ) + SearchModule(Settings.EMPTY, false, emptyList()).namedXContents)
     }
 
     fun Response.asMap(): Map<String, Any> {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunnerIT.kt
@@ -53,7 +53,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor with dryrun`() {
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name}}"), destinationId = createDestination().id)
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
+        val monitor = randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
 
         val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
 
@@ -88,7 +88,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             return ctx.results[0].hits.hits.size() == 1
         """.trimIndent()
 
-        val trigger = randomTrigger(condition = Script(triggerScript))
+        val trigger = randomTraditionalTrigger(condition = Script(triggerScript))
         val monitor = randomMonitor(inputs = listOf(input), triggers = listOf(trigger))
         val response = executeMonitor(monitor, params = DRYRUN_MONITOR)
 
@@ -103,7 +103,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test execute monitor not triggered`() {
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = NEVER_RUN)))
+        val monitor = randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = NEVER_RUN)))
 
         val response = executeMonitor(monitor)
 
@@ -119,7 +119,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test active alert is updated on each run`() {
         val monitor = createMonitor(
-                randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id))))
+                randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id))))
 
         executeMonitor(monitor.id)
         val firstRunAlert = searchAlerts(monitor).single()
@@ -142,7 +142,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         createIndex("foo", Settings.EMPTY)
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
         val monitor = createMonitor(randomMonitor(inputs = listOf(input),
-                triggers = listOf(randomTrigger(condition = NEVER_RUN))))
+                triggers = listOf(randomTraditionalTrigger(condition = NEVER_RUN))))
 
         deleteIndex("foo")
         val response = executeMonitor(monitor.id)
@@ -163,7 +163,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         createIndex("foo", Settings.EMPTY)
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
         val monitor = createMonitor(randomMonitor(inputs = listOf(input),
-                triggers = listOf(randomTrigger(condition = NEVER_RUN))))
+                triggers = listOf(randomTraditionalTrigger(condition = NEVER_RUN))))
 
         var exception: ResponseException? = null
         try {
@@ -181,7 +181,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         val input = SearchInput(indices = listOf("foo"), query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
         val monitor = createMonitor(
                 randomMonitor(inputs = listOf(input),
-                triggers = listOf(randomTrigger(condition = ALWAYS_RUN, destinationId = destinationId))))
+                triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, destinationId = destinationId))))
 
         var response = executeMonitor(monitor.id)
 
@@ -204,7 +204,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test acknowledged alert is not updated unnecessarily`() {
         val monitor = createMonitor(
-                randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id))))
+                randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, destinationId = createDestination().id))))
         executeMonitor(monitor.id)
         acknowledgeAlerts(monitor, searchAlerts(monitor).single())
         val acknowledgedAlert = searchAlerts(monitor).single()
@@ -225,7 +225,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     }
 
     fun `test alert completion`() {
-        val trigger = randomTrigger(condition = Script("ctx.alert == null"), destinationId = createDestination().id)
+        val trigger = randomTraditionalTrigger(condition = Script("ctx.alert == null"), destinationId = createDestination().id)
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
@@ -240,7 +240,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor script error`() {
         // This painless script should cause a syntax error
-        val trigger = randomTrigger(condition = Script("foo bar baz"))
+        val trigger = randomTraditionalTrigger(condition = Script("foo bar baz"))
         val monitor = randomMonitor(triggers = listOf(trigger))
 
         val response = executeMonitor(monitor)
@@ -258,7 +258,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     fun `test execute action template error`() {
         // Intentional syntax error in mustache template
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name"))
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
+        val monitor = randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))))
 
         val response = executeMonitor(monitor)
 
@@ -292,7 +292,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             return ctx.results[0].hits.hits.size() > 0
         """.trimIndent()
         val destinationId = createDestination().id
-        val trigger = randomTrigger(condition = Script(triggerScript), destinationId = destinationId)
+        val trigger = randomTraditionalTrigger(condition = Script(triggerScript), destinationId = destinationId)
         val monitor = createMonitor(randomMonitor(inputs = listOf(input), triggers = listOf(trigger)))
 
         val response = executeMonitor(monitor.id)
@@ -327,7 +327,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
             // make sure there is exactly one hit
             return ctx.results[0].hits.hits.size() == 1
         """.trimIndent()
-        val trigger = randomTrigger(condition = Script(triggerScript))
+        val trigger = randomTraditionalTrigger(condition = Script(triggerScript))
         val monitor = randomMonitor(inputs = listOf(input), triggers = listOf(trigger))
 
         val response = executeMonitor(monitor)
@@ -351,7 +351,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 template = randomTemplateScript("{{foo"),
                 destinationId = createDestination().id)
         val actions = listOf(goodAction, syntaxErrorAction)
-        val monitor = createMonitor(randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = actions))))
+        val monitor = createMonitor(randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, actions = actions))))
 
         val output = entityAsMap(executeMonitor(monitor.id))
 
@@ -378,7 +378,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         putAlertMappings() // Required as we do not have a create alert API.
         // This template script has a parsing error to purposefully create an errorMessage during runMonitor
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name"))
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
         val listOfFiveErrorMessages = (1..5).map { i -> AlertError(timestamp = Instant.now(), message = "error message $i") }
         val activeAlert = createAlert(randomAlert(monitor).copy(state = ACTIVE, errorHistory = listOfFiveErrorMessages,
@@ -400,7 +400,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test latest error is not lost when alert is completed`() {
         // Creates an active alert the first time it's run and completes it the second time the monitor is run.
-        val trigger = randomTrigger(condition = Script("""
+        val trigger = randomTraditionalTrigger(condition = Script("""
             if (ctx.alert == null) {
                 throw new RuntimeException("foo");
             } else {
@@ -424,7 +424,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test throw script exception`() {
         // Creates an active alert the first time it's run and completes it the second time the monitor is run.
-        val trigger = randomTrigger(condition = Script("""
+        val trigger = randomTraditionalTrigger(condition = Script("""
             param[0]; return true
         """.trimIndent()))
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
@@ -441,7 +441,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         putAlertMappings() // Required as we do not have a create alert API.
         // This template script has a parsing error to purposefully create an errorMessage during runMonitor
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name"))
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
         val listOfTenErrorMessages = (1..10).map { i -> AlertError(timestamp = Instant.now(), message = "error message $i") }
         val activeAlert = createAlert(randomAlert(monitor).copy(state = ACTIVE, errorHistory = listOfTenErrorMessages,
@@ -464,7 +464,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
     fun `test execute monitor creates alert for trigger with no actions`() {
         putAlertMappings() // Required as we do not have a create alert API.
 
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = emptyList(), destinationId = createDestination().id)
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = emptyList(), destinationId = createDestination().id)
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
@@ -476,7 +476,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor non-dryrun`() {
         val monitor = createMonitor(
-                randomMonitor(triggers = listOf(randomTrigger(
+                randomMonitor(triggers = listOf(randomTraditionalTrigger(
                         condition = ALWAYS_RUN,
                         actions = listOf(randomAction(destinationId = createDestination().id))))))
 
@@ -490,7 +490,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
 
     fun `test execute monitor with already active alert`() {
         val monitor = createMonitor(
-                randomMonitor(triggers = listOf(randomTrigger(
+                randomMonitor(triggers = listOf(randomTraditionalTrigger(
                         condition = ALWAYS_RUN,
                         actions = listOf(randomAction(destinationId = createDestination().id))))))
 
@@ -513,7 +513,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
         putAlertMappings()
 
         val newMonitor = createMonitor(
-                randomMonitor(triggers = listOf(randomTrigger(condition = NEVER_RUN, actions = listOf(randomAction())))))
+                randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = NEVER_RUN, actions = listOf(randomAction())))))
         val deleteNewMonitorResponse = client().makeRequest("DELETE", "$ALERTING_BASE_URI/${newMonitor.id}")
 
         assertEquals("Delete request not successful", RestStatus.OK, deleteNewMonitorResponse.restStatus())
@@ -556,7 +556,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 destinationId = createDestination().id,
                 throttleEnabled = false, throttle = Throttle(value = 5, unit = MINUTES))
         val actions = listOf(actionThrottleEnabled, actionThrottleNotEnabled)
-        val monitor = createMonitor(randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = actions)),
+        val monitor = createMonitor(randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, actions = actions)),
                 schedule = IntervalSchedule(interval = 1, unit = ChronoUnit.MINUTES)))
         val monitorRunResultNotThrottled = entityAsMap(executeMonitor(monitor.id))
         verifyActionThrottleResults(monitorRunResultNotThrottled, mutableMapOf(Pair(actionThrottleEnabled.id, false),
@@ -590,7 +590,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 destinationId = createDestination().id,
                 throttleEnabled = true, throttle = Throttle(value = 5, unit = MINUTES))
         val actions = listOf(actionThrottleEnabled)
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = actions)
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = actions)
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger),
                 schedule = IntervalSchedule(interval = 1, unit = ChronoUnit.MINUTES)))
         val monitorRunResult1 = entityAsMap(executeMonitor(monitor.id))
@@ -644,7 +644,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                 email = email
         ))
         val action = randomAction(destinationId = destination.id)
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
 
         executeMonitor(monitor.id)
@@ -668,7 +668,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                         email = null
                 ))
         val action = randomAction(destinationId = destination.id)
-        val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
         executeMonitor(adminClient(), monitor.id)
 
@@ -694,7 +694,7 @@ class MonitorRunnerIT : AlertingRestTestCase() {
                             email = null
                     ))
             val action = randomAction(destinationId = destination.id)
-            val trigger = randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))
+            val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))
             val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
             executeMonitor(adminClient(), monitor.id)
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorTests.kt
@@ -45,7 +45,7 @@ class MonitorTests : ESTestCase() {
 
         val tooManyTriggers = mutableListOf<Trigger>()
         for (i in 0..10) {
-            tooManyTriggers.add(randomTrigger())
+            tooManyTriggers.add(randomTraditionalTrigger())
         }
 
         try {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -25,6 +25,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.InputRunResults
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.MonitorRunResult
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
 import com.amazon.opendistroforelasticsearch.alerting.model.TriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action
@@ -67,7 +68,7 @@ fun randomMonitor(
     inputs: List<Input> = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
     schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
     enabled: Boolean = ESTestCase.randomBoolean(),
-    triggers: List<Trigger> = (1..randomInt(10)).map { randomTrigger() },
+    triggers: List<Trigger> = (1..randomInt(10)).map { randomTraditionalTrigger() },
     enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     withMetadata: Boolean = false
@@ -83,7 +84,7 @@ fun randomMonitorWithoutUser(
     inputs: List<Input> = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
     schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
     enabled: Boolean = ESTestCase.randomBoolean(),
-    triggers: List<Trigger> = (1..randomInt(10)).map { randomTrigger() },
+    triggers: List<Trigger> = (1..randomInt(10)).map { randomTraditionalTrigger() },
     enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     withMetadata: Boolean = false
@@ -93,15 +94,15 @@ fun randomMonitorWithoutUser(
         uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
 }
 
-fun randomTrigger(
+fun randomTraditionalTrigger(
     id: String = UUIDs.base64UUID(),
     name: String = ESRestTestCase.randomAlphaOfLength(10),
     severity: String = "1",
     condition: Script = randomScript(),
     actions: List<Action> = mutableListOf(),
     destinationId: String = ""
-): Trigger {
-    return Trigger(
+): TraditionalTrigger {
+    return TraditionalTrigger(
         id = id,
         name = name,
         severity = severity,
@@ -163,7 +164,7 @@ fun randomThrottle(
 ) = Throttle(value, unit)
 
 fun randomAlert(monitor: Monitor = randomMonitor()): Alert {
-    val trigger = randomTrigger()
+    val trigger = randomTraditionalTrigger()
     val actionExecutionResults = mutableListOf(randomActionExecutionResult(), randomActionExecutionResult())
     return Alert(monitor, trigger, Instant.now().truncatedTo(ChronoUnit.MILLIS), null,
             actionExecutionResults = actionExecutionResults)
@@ -301,6 +302,6 @@ fun parser(xc: String): XContentParser {
 
 fun xContentRegistry(): NamedXContentRegistry {
     return NamedXContentRegistry(listOf(
-            SearchInput.XCONTENT_REGISTRY) +
+            SearchInput.XCONTENT_REGISTRY, TraditionalTrigger.XCONTENT_REGISTRY) +
             SearchModule(Settings.EMPTY, false, emptyList()).namedXContents)
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -21,6 +21,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.string
 import com.amazon.opendistroforelasticsearch.alerting.model.ActionExecutionResult
 import com.amazon.opendistroforelasticsearch.alerting.model.ActionRunResult
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.InputRunResults
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
@@ -302,6 +303,6 @@ fun parser(xc: String): XContentParser {
 
 fun xContentRegistry(): NamedXContentRegistry {
     return NamedXContentRegistry(listOf(
-            SearchInput.XCONTENT_REGISTRY, TraditionalTrigger.XCONTENT_REGISTRY) +
+            SearchInput.XCONTENT_REGISTRY, TraditionalTrigger.XCONTENT_REGISTRY, AggregationTrigger.XCONTENT_REGISTRY) +
             SearchModule(Settings.EMPTY, false, emptyList()).namedXContents)
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -65,7 +65,6 @@ fun randomMonitor(
     name: String = ESRestTestCase.randomAlphaOfLength(10),
     user: User = randomUser(),
     inputs: List<Input> = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
-    groupByFields: List<String>? = (1..randomInt(3)).map { ESRestTestCase.randomAlphaOfLength(10) },
     schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
     enabled: Boolean = ESTestCase.randomBoolean(),
     triggers: List<Trigger> = (1..randomInt(10)).map { randomTrigger() },
@@ -73,16 +72,15 @@ fun randomMonitor(
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     withMetadata: Boolean = false
 ): Monitor {
-    return Monitor(name = name, enabled = enabled, inputs = inputs, groupByFields = groupByFields, schedule = schedule, triggers = triggers,
-            enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
-            user = user, uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
+    return Monitor(name = name, monitorType = Monitor.MonitorType.TRADITIONAL_MONITOR, enabled = enabled, inputs = inputs,
+        schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
 }
 
 // Monitor of older versions without security.
 fun randomMonitorWithoutUser(
     name: String = ESRestTestCase.randomAlphaOfLength(10),
     inputs: List<Input> = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
-    groupByFields: List<String> = (1..randomInt(3)).map { ESRestTestCase.randomAlphaOfLength(10) },
     schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
     enabled: Boolean = ESTestCase.randomBoolean(),
     triggers: List<Trigger> = (1..randomInt(10)).map { randomTrigger() },
@@ -90,9 +88,9 @@ fun randomMonitorWithoutUser(
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
     withMetadata: Boolean = false
 ): Monitor {
-    return Monitor(name = name, enabled = enabled, inputs = inputs, groupByFields = groupByFields, schedule = schedule, triggers = triggers,
-            enabledTime = enabledTime, lastUpdateTime = lastUpdateTime,
-            user = null, uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
+    return Monitor(name = name, monitorType = Monitor.MonitorType.TRADITIONAL_MONITOR, enabled = enabled, inputs = inputs,
+        schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = null,
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
 }
 
 fun randomTrigger(

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/GetMonitorResponseTests.kt
@@ -46,9 +46,22 @@ class GetMonitorResponseTests : ESTestCase() {
         val testInstance = Instant.ofEpochSecond(1538164858L)
 
         val cronSchedule = CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance)
-        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK,
-                Monitor("123", 0L, "test-monitor", true, cronSchedule, Instant.now(),
-                        Instant.now(), randomUser(), 0, mutableListOf(), mutableListOf(), mutableListOf(), mutableMapOf()))
+        val monitor = Monitor(
+            id = "123",
+            version = 0L,
+            name = "test-monitor",
+            enabled = true,
+            schedule = cronSchedule,
+            lastUpdateTime = Instant.now(),
+            enabledTime = Instant.now(),
+            monitorType = Monitor.MonitorType.TRADITIONAL_MONITOR,
+            user = randomUser(),
+            schemaVersion = 0,
+            inputs = mutableListOf(),
+            triggers = mutableListOf(),
+            uiMetadata = mutableMapOf()
+        )
+        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor)
         assertNotNull(req)
 
         val out = BytesStreamOutput()

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorResponseTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/action/IndexMonitorResponseTests.kt
@@ -32,9 +32,21 @@ class IndexMonitorResponseTests : ESTestCase() {
         val testInstance = Instant.ofEpochSecond(1538164858L)
 
         val cronSchedule = CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance)
-        val req = IndexMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK,
-                Monitor("123", 0L, "test-monitor", true, cronSchedule, Instant.now(),
-                        Instant.now(), randomUser(), 0, mutableListOf(), mutableListOf(), mutableListOf(), mutableMapOf()))
+        val monitor = Monitor(
+            id = "123",
+            version = 0L,
+            name = "test-monitor",
+            enabled = true,
+            schedule = cronSchedule,
+            lastUpdateTime = Instant.now(),
+            enabledTime = Instant.now(),
+            monitorType = Monitor.MonitorType.TRADITIONAL_MONITOR,
+            user = randomUser(),
+            schemaVersion = 0,
+            inputs = mutableListOf(),
+            triggers = mutableListOf(),
+            uiMetadata = mutableMapOf())
+        val req = IndexMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor)
         assertNotNull(req)
 
         val out = BytesStreamOutput()

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
@@ -20,7 +20,7 @@ import com.amazon.opendistroforelasticsearch.alerting.AlertingRestTestCase
 import com.amazon.opendistroforelasticsearch.alerting.NEVER_RUN
 import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
-import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
+import com.amazon.opendistroforelasticsearch.alerting.randomTraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
 import com.amazon.opendistroforelasticsearch.alerting.makeRequest
 import org.apache.http.entity.ContentType.APPLICATION_JSON
@@ -33,7 +33,7 @@ import org.elasticsearch.rest.RestStatus
 class AlertIndicesIT : AlertingRestTestCase() {
 
     fun `test create alert index`() {
-        executeMonitor(randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN))))
+        executeMonitor(randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN))))
 
         assertIndexExists(AlertIndices.ALERT_INDEX)
         assertIndexExists(AlertIndices.HISTORY_WRITE_INDEX)
@@ -62,7 +62,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
     fun `test alert index gets recreated automatically if deleted`() {
         wipeAllODFEIndices()
         assertIndexDoesNotExist(AlertIndices.ALERT_INDEX)
-        val trueMonitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN)))
+        val trueMonitor = randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN)))
 
         executeMonitor(trueMonitor)
         assertIndexExists(AlertIndices.ALERT_INDEX)
@@ -82,7 +82,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         client().updateSettings(AlertingSettings.ALERT_HISTORY_ROLLOVER_PERIOD.key, "1s")
         client().updateSettings(AlertingSettings.ALERT_HISTORY_INDEX_MAX_AGE.key, "1s")
 
-        val trueMonitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN)))
+        val trueMonitor = randomMonitor(triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN)))
         executeMonitor(trueMonitor)
 
         // Allow for a rollover index.
@@ -93,7 +93,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
     fun `test history disabled`() {
         resetHistorySettings()
 
-        val trigger1 = randomTrigger(condition = ALWAYS_RUN)
+        val trigger1 = randomTraditionalTrigger(condition = ALWAYS_RUN)
         val monitor1 = createMonitor(randomMonitor(triggers = listOf(trigger1)))
         executeMonitor(monitor1.id)
 
@@ -113,7 +113,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         // Disable alert history
         client().updateSettings(AlertingSettings.ALERT_HISTORY_ENABLED.key, "false")
 
-        val trigger2 = randomTrigger(condition = ALWAYS_RUN)
+        val trigger2 = randomTraditionalTrigger(condition = ALWAYS_RUN)
         val monitor2 = createMonitor(randomMonitor(triggers = listOf(trigger2)))
         executeMonitor(monitor2.id)
 
@@ -138,7 +138,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         resetHistorySettings()
 
         // Create monitor and execute
-        val trigger = randomTrigger(condition = ALWAYS_RUN)
+        val trigger = randomTraditionalTrigger(condition = ALWAYS_RUN)
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
         executeMonitor(monitor.id)
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/WriteableTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/WriteableTests.kt
@@ -28,7 +28,7 @@ import com.amazon.opendistroforelasticsearch.alerting.randomInputRunResults
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitorRunResult
 import com.amazon.opendistroforelasticsearch.alerting.randomThrottle
-import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
+import com.amazon.opendistroforelasticsearch.alerting.randomTraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.randomTriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.randomUser
 import com.amazon.opendistroforelasticsearch.alerting.randomUserEmpty
@@ -94,12 +94,12 @@ class WriteableTests : ESTestCase() {
         assertEquals("Round tripping Monitor doesn't work", monitor, newMonitor)
     }
 
-    fun `test trigger as stream`() {
-        val trigger = randomTrigger()
+    fun `test traditional trigger as stream`() {
+        val trigger = randomTraditionalTrigger()
         val out = BytesStreamOutput()
         trigger.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
-        val newTrigger = Trigger(sin)
+        val newTrigger = TraditionalTrigger.readFrom(sin)
         assertEquals("Round tripping Trigger doesn't work", trigger, newTrigger)
     }
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/MonitorRestApiIT.kt
@@ -26,7 +26,7 @@ import com.amazon.opendistroforelasticsearch.alerting.core.settings.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.makeRequest
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
-import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.randomADMonitor
 import com.amazon.opendistroforelasticsearch.alerting.randomAction
 import com.amazon.opendistroforelasticsearch.alerting.randomAlert
@@ -34,7 +34,7 @@ import com.amazon.opendistroforelasticsearch.alerting.randomAnomalyDetector
 import com.amazon.opendistroforelasticsearch.alerting.randomAnomalyDetectorWithUser
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
 import com.amazon.opendistroforelasticsearch.alerting.randomThrottle
-import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
+import com.amazon.opendistroforelasticsearch.alerting.randomTraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
 import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType
@@ -284,7 +284,14 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test updating conditions for a monitor`() {
         val monitor = createRandomMonitor()
 
-        val updatedTriggers = listOf(Trigger("foo", "1", Script("return true"), emptyList()))
+        val updatedTriggers = listOf(
+            TraditionalTrigger(
+                name = "foo",
+                severity = "1",
+                condition = Script("return true"),
+                actions = emptyList()
+            )
+        )
         val updateResponse = client().makeRequest("PUT", monitor.relativeUrl(),
                 emptyMap(), monitor.copy(triggers = updatedTriggers).toHttpEntity())
 
@@ -649,7 +656,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test delete trigger moves alerts`() {
         client().updateSettings(ScheduledJobSettings.SWEEPER_ENABLED.key, true)
         putAlertMappings()
-        val trigger = randomTrigger()
+        val trigger = randomTraditionalTrigger()
         val monitor = createMonitor(randomMonitor(triggers = listOf(trigger)))
         val alert = createAlert(randomAlert(monitor).copy(triggerId = trigger.id, state = Alert.State.ACTIVE))
         refreshIndex("*")
@@ -672,8 +679,8 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     fun `test delete trigger moves alerts only for deleted trigger`() {
         client().updateSettings(ScheduledJobSettings.SWEEPER_ENABLED.key, true)
         putAlertMappings()
-        val triggerToDelete = randomTrigger()
-        val triggerToKeep = randomTrigger()
+        val triggerToDelete = randomTraditionalTrigger()
+        val triggerToKeep = randomTraditionalTrigger()
         val monitor = createMonitor(randomMonitor(triggers = listOf(triggerToDelete, triggerToKeep)))
         val alertKeep = createAlert(randomAlert(monitor).copy(triggerId = triggerToKeep.id, state = Alert.State.ACTIVE))
         val alertDelete = createAlert(randomAlert(monitor).copy(triggerId = triggerToDelete.id, state = Alert.State.ACTIVE))
@@ -806,7 +813,7 @@ class MonitorRestApiIT : AlertingRestTestCase() {
     private fun randomMonitorWithThrottle(value: Int, unit: ChronoUnit = ChronoUnit.MINUTES): Monitor {
         val throttle = randomThrottle(value, unit)
         val action = randomAction().copy(throttle = throttle)
-        val trigger = randomTrigger(actions = listOf(action))
+        val trigger = randomTraditionalTrigger(actions = listOf(action))
         return randomMonitor(triggers = listOf(trigger))
     }
 }

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/resthandler/SecureMonitorRestApiIT.kt
@@ -11,7 +11,7 @@ import com.amazon.opendistroforelasticsearch.alerting.randomAction
 import com.amazon.opendistroforelasticsearch.alerting.randomAlert
 import com.amazon.opendistroforelasticsearch.alerting.randomMonitor
 import com.amazon.opendistroforelasticsearch.alerting.randomTemplateScript
-import com.amazon.opendistroforelasticsearch.alerting.randomTrigger
+import com.amazon.opendistroforelasticsearch.alerting.randomTraditionalTrigger
 import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.commons.rest.SecureRestClientBuilder
 import org.apache.http.entity.ContentType
@@ -413,12 +413,13 @@ class SecureMonitorRestApiIT : AlertingRestTestCase() {
 
         val action = randomAction(template = randomTemplateScript("Hello {{ctx.monitor.name}}"), destinationId = createDestination().id)
         val inputs = listOf(
-                SearchInput(
-                        indices = kotlin.collections.listOf("not_hr_data"),
-                        query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
-                )
+            SearchInput(
+                indices = listOf("not_hr_data"),
+                query = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
+            )
         )
-        val monitor = randomMonitor(triggers = listOf(randomTrigger(condition = ALWAYS_RUN, actions = listOf(action))), inputs = inputs)
+        val monitor = randomMonitor(
+            triggers = listOf(randomTraditionalTrigger(condition = ALWAYS_RUN, actions = listOf(action))), inputs = inputs)
 
         // Make sure the elevating the permissions fails execute.
         val adminUser = User("admin", listOf("admin"), listOf("all_access"), listOf())

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -118,15 +118,6 @@
             }
           }
         },
-        "group_by_fields": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          }
-        },
         "triggers": {
           "type": "nested",
           "properties": {
@@ -179,6 +170,64 @@
                     },
                     "unit": {
                       "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "traditional_trigger": {
+              "properties": {
+                "name": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 256
+                    }
+                  }
+                },
+                "min_time_between_executions": {
+                  "type": "integer"
+                },
+                "condition": {
+                  "type": "object",
+                  "enabled": false
+                },
+                "actions": {
+                  "type": "nested",
+                  "properties": {
+                    "name": {
+                      "type": "text",
+                      "fields": {
+                        "keyword": {
+                          "type": "keyword",
+                          "ignore_above": 256
+                        }
+                      }
+                    },
+                    "destination_id": {
+                      "type": "keyword"
+                    },
+                    "subject_template": {
+                      "type": "object",
+                      "enabled": false
+                    },
+                    "message_template": {
+                      "type": "object",
+                      "enabled": false
+                    },
+                    "throttle_enabled": {
+                      "type": "boolean"
+                    },
+                    "throttle": {
+                      "properties": {
+                        "value": {
+                          "type": "integer"
+                        },
+                        "unit": {
+                          "type": "keyword"
+                        }
+                      }
                     }
                   }
                 }

--- a/core/src/main/resources/mappings/scheduled-jobs.json
+++ b/core/src/main/resources/mappings/scheduled-jobs.json
@@ -18,6 +18,9 @@
             }
           }
         },
+        "monitor_type": {
+          "type": "keyword"
+        },
         "user": {
           "properties": {
             "name": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For Document-Level Alerting, a new Trigger type will be introduced. To scale for this change, Trigger was refactored to be an interface. The current Trigger is now referred to as `TraditionalTrigger`.

Monitor now has `monitor_type`s where the current Monitor is referred to as a `traditional_monitor` and uses `TraditionalTriggers`. The aggregation/multi-alert Alerting behavior will be available in `aggregation_monitor`s which will use `AggregationTrigger`s. These names are not set in stone, it was mostly to differentiate the implementations.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
