### PR TITLE
AggregationTrigger implementation

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregationBuilder.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregationBuilder.kt
@@ -33,7 +33,7 @@ import java.util.Objects
 class BucketSelectorExtAggregationBuilder :
     AbstractPipelineAggregationBuilder<BucketSelectorExtAggregationBuilder> {
     private val bucketsPathsMap: MutableMap<String, String>
-    private val parentBucketPath: String
+    val parentBucketPath: String
     val script: Script
     val filter: BucketSelectorExtFilter?
     private var gapPolicy = GapPolicy.SKIP
@@ -140,7 +140,7 @@ class BucketSelectorExtAggregationBuilder :
 
     companion object {
         val NAME = ParseField("bucket_selector_ext")
-        private val PARENT_BUCKET_PATH = ParseField("parent_bucket_path")
+        val PARENT_BUCKET_PATH = ParseField("parent_bucket_path")
 
         @Throws(IOException::class)
         fun parse(reducerName: String, parser: XContentParser): BucketSelectorExtAggregationBuilder {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTrigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTrigger.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.alerting.model
 
+import com.amazon.opendistroforelasticsearch.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ACTIONS_FIELD
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.ID_FIELD
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger.Companion.NAME_FIELD
@@ -41,8 +42,8 @@ data class AggregationTrigger(
     override val id: String = UUIDs.base64UUID(),
     override val name: String,
     override val severity: String,
+    val bucketSelector: BucketSelectorExtAggregationBuilder,
     override val actions: List<Action>
-    // TODO: Add the remaining member variables based on integrated with Trigger pipeline aggregator
 ) : Trigger {
 
     // TODO: Once class is full implemented add tests to the following suites:
@@ -54,8 +55,8 @@ data class AggregationTrigger(
         sin.readString(), // id
         sin.readString(), // name
         sin.readString(), // severity
+        BucketSelectorExtAggregationBuilder(sin), // condition
         sin.readList(::Action) // actions
-        // TODO: Add remainder of inputs after integration
     )
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -64,8 +65,10 @@ data class AggregationTrigger(
             .field(ID_FIELD, id)
             .field(NAME_FIELD, name)
             .field(SEVERITY_FIELD, severity)
+            .startObject(CONDITION_FIELD)
+        bucketSelector.internalXContent(builder, params)
+        builder.endObject()
             .field(ACTIONS_FIELD, actions.toTypedArray())
-            // TODO: Add remainder of contents after integration
             .endObject()
             .endObject()
         return builder
@@ -80,12 +83,24 @@ data class AggregationTrigger(
         out.writeString(id)
         out.writeString(name)
         out.writeString(severity)
+        bucketSelector.writeTo(out)
         out.writeCollection(actions)
-        // TODO: Add remainder of outputs after integration
+    }
+
+    fun asTemplateArg(): Map<String, Any> {
+        return mapOf(ID_FIELD to id, NAME_FIELD to name, SEVERITY_FIELD to severity,
+            ACTIONS_FIELD to actions.map { it.asTemplateArg() },
+            AGGREGATION_TRIGGER_FIELD to {
+                mapOf(
+                    BucketSelectorExtAggregationBuilder.NAME.preferredName to bucketSelector.name,
+                    BucketSelectorExtAggregationBuilder.PARENT_BUCKET_PATH.preferredName to bucketSelector.parentBucketPath
+                )
+            })
     }
 
     companion object {
         const val AGGREGATION_TRIGGER_FIELD = "aggregation_trigger"
+        const val CONDITION_FIELD = "condition"
 
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(Trigger::class.java, ParseField(AGGREGATION_TRIGGER_FIELD),
             CheckedFunction { parseInner(it) })
@@ -98,6 +113,7 @@ data class AggregationTrigger(
             lateinit var severity: String
             val actions: MutableList<Action> = mutableListOf()
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp)
+            lateinit var bucketSelector: BucketSelectorExtAggregationBuilder
 
             while (xcp.nextToken() != Token.END_OBJECT) {
                 val fieldName = xcp.currentName()
@@ -107,13 +123,15 @@ data class AggregationTrigger(
                     ID_FIELD -> id = xcp.text()
                     NAME_FIELD -> name = xcp.text()
                     SEVERITY_FIELD -> severity = xcp.text()
+                    CONDITION_FIELD -> {
+                        bucketSelector = BucketSelectorExtAggregationBuilder.parse(name, xcp)
+                    }
                     ACTIONS_FIELD -> {
                         ensureExpectedToken(Token.START_ARRAY, xcp.currentToken(), xcp)
                         while (xcp.nextToken() != Token.END_ARRAY) {
                             actions.add(Action.parse(xcp))
                         }
                     }
-                    // TODO: Add remainder of field to parse after integration
                 }
             }
 
@@ -121,6 +139,7 @@ data class AggregationTrigger(
                 id = requireNotNull(id) { "Trigger id is null." },
                 name = requireNotNull(name) { "Trigger name is null" },
                 severity = requireNotNull(severity) { "Trigger severity is null" },
+                bucketSelector = bucketSelector,
                 actions = requireNotNull(actions) { "Trigger actions are null" })
         }
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTrigger.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTrigger.kt
@@ -46,10 +46,6 @@ data class AggregationTrigger(
     override val actions: List<Action>
 ) : Trigger {
 
-    // TODO: Once class is full implemented add tests to the following suites:
-    //  - WriteableTests
-    //  - XContentTests
-
     @Throws(IOException::class)
     constructor(sin: StreamInput): this(
         sin.readString(), // id

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -118,7 +118,7 @@ fun randomAggregationTrigger(
     id: String = UUIDs.base64UUID(),
     name: String = ESRestTestCase.randomAlphaOfLength(10),
     severity: String = "1",
-    bucketSelector: BucketSelectorExtAggregationBuilder = randomBucketSelectorExtAggregationBuilder(name=name),
+    bucketSelector: BucketSelectorExtAggregationBuilder = randomBucketSelectorExtAggregationBuilder(name = name),
     actions: List<Action> = mutableListOf(),
     destinationId: String = ""
 ): AggregationTrigger {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -14,6 +14,8 @@
  */
 package com.amazon.opendistroforelasticsearch.alerting
 
+import com.amazon.opendistroforelasticsearch.alerting.aggregation.bucketselectorext.BucketSelectorExtAggregationBuilder
+import com.amazon.opendistroforelasticsearch.alerting.aggregation.bucketselectorext.BucketSelectorExtFilter
 import com.amazon.opendistroforelasticsearch.alerting.core.model.Input
 import com.amazon.opendistroforelasticsearch.alerting.core.model.IntervalSchedule
 import com.amazon.opendistroforelasticsearch.alerting.core.model.Schedule
@@ -55,6 +57,7 @@ import org.elasticsearch.index.query.QueryBuilders
 import org.elasticsearch.script.Script
 import org.elasticsearch.script.ScriptType
 import org.elasticsearch.search.SearchModule
+import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude
 import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.elasticsearch.test.ESTestCase
 import org.elasticsearch.test.ESTestCase.randomInt
@@ -109,6 +112,39 @@ fun randomTraditionalTrigger(
         severity = severity,
         condition = condition,
         actions = if (actions.isEmpty()) (0..randomInt(10)).map { randomAction(destinationId = destinationId) } else actions)
+}
+
+fun randomAggregationTrigger(
+    id: String = UUIDs.base64UUID(),
+    name: String = ESRestTestCase.randomAlphaOfLength(10),
+    severity: String = "1",
+    bucketSelector: BucketSelectorExtAggregationBuilder = randomBucketSelectorExtAggregationBuilder(name=name),
+    actions: List<Action> = mutableListOf(),
+    destinationId: String = ""
+): AggregationTrigger {
+    return AggregationTrigger(
+        id = id,
+        name = name,
+        severity = severity,
+        bucketSelector = bucketSelector,
+        actions = if (actions.isEmpty()) (0..randomInt(10)).map { randomAction(destinationId = destinationId) } else actions)
+}
+
+fun randomBucketSelectorExtAggregationBuilder(
+    name: String = ESRestTestCase.randomAlphaOfLength(10),
+    bucketsPathsMap: MutableMap<String, String> = mutableMapOf("avg" to "10"),
+    script: Script = randomBucketSelectorScript(params=bucketsPathsMap),
+    parentBucketPath: String = "testPath",
+    filter: BucketSelectorExtFilter = BucketSelectorExtFilter(IncludeExclude("foo*", "bar*"))
+    ) : BucketSelectorExtAggregationBuilder {
+    return BucketSelectorExtAggregationBuilder(name, bucketsPathsMap, script, parentBucketPath, filter)
+}
+
+fun randomBucketSelectorScript(
+    idOrCode: String = "params.avg >= 0",
+    params: Map<String, String> = mutableMapOf("avg" to "10")
+): Script {
+    return Script(Script.DEFAULT_SCRIPT_TYPE, Script.DEFAULT_SCRIPT_LANG, idOrCode, emptyMap<String, String>(), params)
 }
 
 fun randomEmailAccount(

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTriggerTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTriggerTests.kt
@@ -1,4 +1,0 @@
-package com.amazon.opendistroforelasticsearch.alerting.model
-
-class AggregationTriggerTests {
-}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTriggerTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTriggerTests.kt
@@ -1,0 +1,4 @@
+package com.amazon.opendistroforelasticsearch.alerting.model
+
+class AggregationTriggerTests {
+}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/WriteableTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/WriteableTests.kt
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.Em
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.EmailGroup
 import com.amazon.opendistroforelasticsearch.alerting.randomAction
 import com.amazon.opendistroforelasticsearch.alerting.randomActionRunResult
+import com.amazon.opendistroforelasticsearch.alerting.randomAggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.randomEmailAccount
 import com.amazon.opendistroforelasticsearch.alerting.randomEmailGroup
 import com.amazon.opendistroforelasticsearch.alerting.randomInputRunResults
@@ -100,6 +101,15 @@ class WriteableTests : ESTestCase() {
         trigger.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newTrigger = TraditionalTrigger.readFrom(sin)
+        assertEquals("Round tripping Trigger doesn't work", trigger, newTrigger)
+    }
+
+    fun `test aggregation trigger as stream`() {
+        val trigger = randomAggregationTrigger()
+        val out = BytesStreamOutput()
+        trigger.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newTrigger = AggregationTrigger.readFrom(sin)
         assertEquals("Round tripping Trigger doesn't work", trigger, newTrigger)
     }
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/XContentTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/XContentTests.kt
@@ -24,6 +24,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.Em
 import com.amazon.opendistroforelasticsearch.alerting.parser
 import com.amazon.opendistroforelasticsearch.alerting.randomAction
 import com.amazon.opendistroforelasticsearch.alerting.randomActionExecutionResult
+import com.amazon.opendistroforelasticsearch.alerting.randomAggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.randomAlert
 import com.amazon.opendistroforelasticsearch.alerting.randomEmailAccount
 import com.amazon.opendistroforelasticsearch.alerting.randomEmailGroup
@@ -105,7 +106,16 @@ class XContentTests : ESTestCase() {
         val triggerString = trigger.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
         val parsedTrigger = Trigger.parse(parser(triggerString))
 
-        assertEquals("Round tripping Trigger doesn't work", trigger, parsedTrigger)
+        assertEquals("Round tripping TraditionalTrigger doesn't work", trigger, parsedTrigger)
+    }
+
+    fun `test aggregation trigger parsing`() {
+        val trigger = randomAggregationTrigger()
+
+        val triggerString = trigger.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedTrigger = Trigger.parse(parser(triggerString))
+
+        assertEquals("Round tripping AggregationTrigger doesn't work", trigger, parsedTrigger)
     }
 
     fun `test alert parsing`() {


### PR DESCRIPTION
* UTs for AggregationTrigger

*Description of changes:*
Implementation of AggregationTrigger. It replaces and also introduces additional fields for AggregationTrigger. Trigger definition would look like - 

```json
  "triggers": [{
    "aggregation_trigger": {
      "name": "test-trigger",
      "severity": "1",
      "condition": {
        "buckets_path": {
          "avg": "goals_stats.avg"
        },
        "script": {
          "source": "params.avg >= 0 "
        },
        "parent_bucket_path": "<path_to_parent_bucket>",
        "filter": {
           "include": ["foo*", "bar*"]
        }
      },
      "actions": [{
         ...
      }]
    }
  }]

```
For details on usage of `BucketSelectorExt` pipeline aggregation, refer the documentation in PR: https://github.com/opendistro-for-elasticsearch/alerting/pull/374
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
