### PR TITLE
Categorizing Alerts and executing Actions for Aggregation Monitors

### DIFF
--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -63,6 +63,10 @@ configurations.all {
     }
 }
 
+configurations.testCompile {
+    exclude module: "securemock"
+}
+
 dependencies {
     compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${versions.elasticsearch}"
 
@@ -76,6 +80,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.3.3"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testCompile "org.mockito:mockito-core:2.23.0"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertService.kt
@@ -27,7 +27,6 @@ import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
-import com.amazon.opendistroforelasticsearch.alerting.script.AggregationTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TraditionalTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils
 import com.amazon.opendistroforelasticsearch.alerting.util.getBucketKeysHash
@@ -108,7 +107,11 @@ class AlertService(
         }
     }
 
-    fun composeTraditionalAlert(ctx: TraditionalTriggerExecutionContext, result: TraditionalTriggerRunResult, alertError: AlertError?): Alert? {
+    fun composeTraditionalAlert(
+        ctx: TraditionalTriggerExecutionContext,
+        result: TraditionalTriggerRunResult,
+        alertError: AlertError?
+    ): Alert? {
         val currentTime = Instant.now()
         val currentAlert = ctx.alert
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertService.kt
@@ -21,13 +21,16 @@ import com.amazon.opendistroforelasticsearch.alerting.elasticapi.firstFailureOrN
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.retry
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.suspendUntil
 import com.amazon.opendistroforelasticsearch.alerting.model.ActionExecutionResult
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationResultBucket
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
-import com.amazon.opendistroforelasticsearch.alerting.model.TriggerRunResult
+import com.amazon.opendistroforelasticsearch.alerting.script.AggregationTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TraditionalTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.util.IndexUtils
+import com.amazon.opendistroforelasticsearch.alerting.util.getBucketKeysHash
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.DocWriteRequest
@@ -86,7 +89,7 @@ class AlertService(
 
     // TODO: For now this is largely a duplicate of the regular loadCurrentAlerts()
     //  The original method could be refactored to support Set if this is the final usage
-    suspend fun loadCurrentAlertsForAggregationMonitor(monitor: Monitor): Map<Trigger, Set<Alert>?> {
+    suspend fun loadCurrentAlertsForAggregationMonitor(monitor: Monitor): Map<Trigger, Map<String, Alert>?> {
         val request = SearchRequest(AlertIndices.ALERT_INDEX)
             .routing(monitor.id)
             .source(alertQuery(monitor))
@@ -98,8 +101,10 @@ class AlertService(
         val foundAlerts = response.hits.map { Alert.parse(contentParser(it.sourceRef), it.id, it.version) }
             .groupBy { it.triggerId }
 
-        return monitor.triggers.associate { trigger ->
-            trigger to (foundAlerts[trigger.id]?.toSet())
+        return monitor.triggers.associateWith { trigger ->
+            foundAlerts[trigger.id]?.mapNotNull { alert ->
+                alert.aggregationResultBucket?.let { it.getBucketKeysHash() to alert }
+            }?.toMap()
         }
     }
 
@@ -124,11 +129,11 @@ class AlertService(
                 }
             }
             // add action execution results which not exist in current alert
-            updatedActionExecutionResults.addAll(result.actionResults.filter { it -> !currentActionIds.contains(it.key) }
-                .map { it -> ActionExecutionResult(it.key, it.value.executionTime, if (it.value.throttled) 1 else 0) })
+            updatedActionExecutionResults.addAll(result.actionResults.filter { !currentActionIds.contains(it.key) }
+                .map { ActionExecutionResult(it.key, it.value.executionTime, if (it.value.throttled) 1 else 0) })
         } else {
-            updatedActionExecutionResults.addAll(result.actionResults.map { it -> ActionExecutionResult(it.key, it.value.executionTime,
-                if (it.value.throttled) 1 else 0) })
+            updatedActionExecutionResults.addAll(result.actionResults.map {
+                ActionExecutionResult(it.key, it.value.executionTime, if (it.value.throttled) 1 else 0) })
         }
 
         // Merge the alert's error message to the current alert's history
@@ -151,6 +156,55 @@ class AlertService(
                 errorHistory = updatedHistory, actionExecutionResults = updatedActionExecutionResults,
                 schemaVersion = IndexUtils.alertIndexSchemaVersion)
         }
+    }
+
+    // TODO: Change the parameters to use result: AggTriggerRunResult instead of currentAlerts and aggResultBuckets after integration
+    fun getCategorizedAlertsForAggregationMonitor(
+        monitor: Monitor,
+        trigger: AggregationTrigger,
+        currentAlerts: Map<String, Alert>?,
+        aggResultBuckets: List<AggregationResultBucket>
+    ): CategorizedAlerts {
+        val dedupedAlerts = mutableListOf<Alert>()
+        val newAlerts = mutableListOf<Alert>()
+        var completedAlerts = listOf<Alert>()
+        val currentTime = Instant.now()
+
+        // TODO: Need to update errorHistory and actionExecutionResults after Actions are run for these alerts (likely in MonitorRunner)
+        aggResultBuckets.forEach { aggAlertBucket ->
+            val currentAlert = currentAlerts?.get(aggAlertBucket.getBucketKeysHash())
+            if (currentAlert != null) {
+                // De-duped Alert
+                dedupedAlerts.add(currentAlert.copy(lastNotificationTime = currentTime))
+            } else {
+                // New Alert
+                // TODO: Setting lastNotificationTime is deceiving since the actions haven't run yet, maybe it should be null here
+                val newAlert = Alert(monitor = monitor, trigger = trigger, startTime = currentTime,
+                    lastNotificationTime = currentTime, state = Alert.State.ACTIVE, errorMessage = null,
+                    errorHistory = mutableListOf(), actionExecutionResults = mutableListOf(),
+                    schemaVersion = IndexUtils.alertIndexSchemaVersion, aggregationResultBucket = aggAlertBucket)
+                newAlerts.add(newAlert)
+            }
+        }
+
+        // The completed alerts can be determined by getting the difference of the current alerts and the de-duped alerts
+        if (currentAlerts != null) {
+            // Creating a set of the deduped Alert bucketKeys hashes for easy checking against currentAlerts
+            // These Alerts should always contain an aggregationResultBucket
+            val dedupedAlertsKeys = dedupedAlerts.map { it.aggregationResultBucket!!.getBucketKeysHash() }.toSet()
+            // Take all Alerts from currentAlerts that do not contain their bucketKeys hashes in dedupedAlerts to get the difference between
+            // the two
+            completedAlerts = currentAlerts.filterNot { dedupedAlertsKeys.contains(it.key) }
+                .map {
+                    // TODO: errorHistory and actionExecutionResults will need to be updated after Action execution when sending
+                    //  messages on COMPLETED alerts is supported
+                    it.value.copy(state = Alert.State.COMPLETED, endTime = currentTime, errorMessage = null,
+                        schemaVersion = IndexUtils.alertIndexSchemaVersion)
+                }
+        }
+
+        // TODO: Should dedupedAlerts and newAlerts be converted to unmodifiableList to ensure the CategorizedAlerts object isn't changed?
+        return CategorizedAlerts(dedupedAlerts, newAlerts, completedAlerts)
     }
 
     suspend fun saveAlerts(alerts: List<Alert>, retryPolicy: BackoffPolicy) {
@@ -223,4 +277,6 @@ class AlertService(
             else -> throw IllegalStateException("Unreachable code reached!")
         }
     }
+
+    data class CategorizedAlerts(val dedupedAlerts: List<Alert>, val newAlerts: List<Alert>, val completedAlerts: List<Alert>)
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.alerting
 
-import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertError
 import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertIndices
 import com.amazon.opendistroforelasticsearch.alerting.alerts.moveAlerts
 import com.amazon.opendistroforelasticsearch.alerting.core.JobRunner
@@ -37,7 +36,6 @@ import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Compan
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Companion.MESSAGE_ID
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Companion.SUBJECT
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.DestinationContextFactory
-import com.amazon.opendistroforelasticsearch.alerting.model.userErrorMessage
 import com.amazon.opendistroforelasticsearch.alerting.script.AggregationTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TraditionalTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TriggerExecutionContext

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/MonitorRunner.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.alerting
 
+import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertError
 import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertIndices
 import com.amazon.opendistroforelasticsearch.alerting.alerts.moveAlerts
 import com.amazon.opendistroforelasticsearch.alerting.core.JobRunner
@@ -22,6 +23,8 @@ import com.amazon.opendistroforelasticsearch.alerting.core.model.ScheduledJob
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.InjectorContextElement
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.retry
 import com.amazon.opendistroforelasticsearch.alerting.model.ActionRunResult
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationResultBucket
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.AlertingConfigAccessor
@@ -34,7 +37,10 @@ import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Compan
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Companion.MESSAGE_ID
 import com.amazon.opendistroforelasticsearch.alerting.model.action.Action.Companion.SUBJECT
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.DestinationContextFactory
+import com.amazon.opendistroforelasticsearch.alerting.model.userErrorMessage
+import com.amazon.opendistroforelasticsearch.alerting.script.AggregationTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TraditionalTriggerExecutionContext
+import com.amazon.opendistroforelasticsearch.alerting.script.TriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings.Companion.ALERT_BACKOFF_COUNT
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings.Companion.ALERT_BACKOFF_MILLIS
 import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings.Companion.MOVE_ALERTS_BACKOFF_COUNT
@@ -45,6 +51,7 @@ import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettin
 import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings.Companion.HOST_DENY_LIST
 import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings.Companion.HOST_DENY_LIST_NONE
 import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings.Companion.loadDestinationSettings
+import com.amazon.opendistroforelasticsearch.alerting.util.getBucketKeysHash
 import com.amazon.opendistroforelasticsearch.alerting.util.isADMonitor
 import com.amazon.opendistroforelasticsearch.alerting.util.isAggregationMonitor
 import com.amazon.opendistroforelasticsearch.alerting.util.isAllowed
@@ -333,17 +340,55 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
             monitorResult = monitorResult.copy(inputResults = inputService.collectInputResults(monitor, periodStart, periodEnd))
         }
 
-        // TODO: Iterate through buckets and execute Trigger scripts against each bucket creating a Trigger -> buckets mappings for alert
-        //  creation.
+        for (trigger in monitor.triggers) {
+            val currentAlertsForTrigger = currentAlerts[trigger]
+            val triggerCtx = AggregationTriggerExecutionContext(monitor, trigger as AggregationTrigger, monitorResult)
+            val triggerResult = triggerService.runAggregationTrigger(monitor, trigger, triggerCtx)
+            // TODO: Should triggerResult's aggregationResultBucket be a list? If not, getCategorizedAlertsForAggregationMonitor can
+            //  be refactored to use a map instead
+            val categorizedAlerts = alertService.getCategorizedAlertsForAggregationMonitor(monitor, trigger, currentAlertsForTrigger,
+                triggerResult.aggregationResultBuckets.values as List<AggregationResultBucket>)
+            val dedupedAlerts = categorizedAlerts.dedupedAlerts
+            val newAlerts = categorizedAlerts.newAlerts
+            val completedAlerts = categorizedAlerts.completedAlerts
 
-        // TODO: Separate buckets/alerts into categories so that the alerts can be created/updated accordingly:
-        //  * De-duped alerts = currentAlerts U filteredBuckets
-        //  * Completed alerts = currentAlerts - de-duped alerts
-        //  * New alerts = filteredBuckets - de-duped alerts
+            // Index alerts here so they are available at the time the Actions are executed.
+            // Note: Index operations can fail for various reasons (such as write blocks on cluster). In this case, the Actions will still
+            // execute with the alert information in the ctx but the alerts will not be visible or have been stored.
+            alertService.saveAlerts(dedupedAlerts, retryPolicy)
+            alertService.saveAlerts(newAlerts, retryPolicy)
+            alertService.saveAlerts(completedAlerts, retryPolicy)
 
-        // TODO: Run Actions for a Trigger and compose alerts
+            // TODO: For now Actions are being executed for each Alert (de-duped or new).
+            //  This will be extended to include suppression logic and supporting executing Actions per run and will be cleaned up as well.
+            for (alert in dedupedAlerts) {
+                val actionCtx = triggerCtx.copy(dedupedAlerts = listOf(alert), newAlerts = listOf(), completedAlerts = completedAlerts,
+                    error = monitorResult.error ?: triggerResult.error)
+                // TODO: AggregationResultBucket shouldn't be null here, but is there a better way than using the non-null assertion operator?
+                val alertBucketKeysHash = alert.aggregationResultBucket!!.getBucketKeysHash()
+                triggerResult.actionResultsMap[alertBucketKeysHash] = mutableMapOf()
+                for (action in trigger.actions) {
+                    val actionResult = runAction(action, actionCtx, dryrun)
+                    triggerResult.actionResultsMap[alertBucketKeysHash]?.set(action.id, actionResult)
+                }
+            }
 
-        // TODO: Update alerts in alerting config index
+            for (alert in newAlerts) {
+                // TODO: This is a duplicate of the above aside from the difference in actionCtx, should be combined when adding suppression logic
+                val actionCtx = triggerCtx.copy(dedupedAlerts = listOf(), newAlerts = listOf(alert), completedAlerts = completedAlerts,
+                    error = monitorResult.error ?: triggerResult.error)
+                val alertBucketKeysHash = alert.aggregationResultBucket!!.getBucketKeysHash()
+                triggerResult.actionResultsMap[alertBucketKeysHash] = mutableMapOf()
+                for (action in trigger.actions) {
+                    val actionResult = runAction(action, actionCtx, dryrun)
+                    triggerResult.actionResultsMap[alertBucketKeysHash]?.set(action.id, actionResult)
+                }
+            }
+
+            // TODO: Originally, only Alerts that had Action failures would have another round of index operations here.
+            //  However, after taking a closer look, it seems that all Alerts will need their actionExecutionResults updated no matter what.
+            //  Will need to take another look at this and see how Alert composition and update logic can be made cleaner.
+        }
 
         return monitorResult
     }
@@ -416,7 +461,39 @@ object MonitorRunner : JobRunner, CoroutineScope, AbstractLifecycleComponent() {
         }
     }
 
-    private fun compileTemplate(template: Script, ctx: TraditionalTriggerExecutionContext): String {
+    // TODO: This is largely a duplicate of runAction above for AggregationTriggerExecutionContext for now.
+    //   After suppression logic implementation, if this remains mostly the same, it can be refactored.
+    private suspend fun runAction(action: Action, ctx: AggregationTriggerExecutionContext, dryrun: Boolean): ActionRunResult {
+        return try {
+            val actionOutput = mutableMapOf<String, String>()
+            actionOutput[SUBJECT] = if (action.subjectTemplate != null) compileTemplate(action.subjectTemplate, ctx) else ""
+            actionOutput[MESSAGE] = compileTemplate(action.messageTemplate, ctx)
+            if (Strings.isNullOrEmpty(actionOutput[MESSAGE])) {
+                throw IllegalStateException("Message content missing in the Destination with id: ${action.destinationId}")
+            }
+            if (!dryrun) {
+                withContext(Dispatchers.IO) {
+                    val destination = AlertingConfigAccessor.getDestinationInfo(client, xContentRegistry, action.destinationId)
+                    if (!destination.isAllowed(allowList)) {
+                        throw IllegalStateException("Monitor contains a Destination type that is not allowed: ${destination.type}")
+                    }
+
+                    val destinationCtx = destinationContextFactory.getDestinationContext(destination)
+                    actionOutput[MESSAGE_ID] = destination.publish(
+                        actionOutput[SUBJECT],
+                        actionOutput[MESSAGE]!!,
+                        destinationCtx,
+                        hostDenyList
+                    )
+                }
+            }
+            ActionRunResult(action.id, action.name, actionOutput, false, currentTime(), null)
+        } catch (e: Exception) {
+            ActionRunResult(action.id, action.name, mapOf(), false, currentTime(), e)
+        }
+    }
+
+    private fun compileTemplate(template: Script, ctx: TriggerExecutionContext): String {
         return scriptService.compile(template, TemplateScript.CONTEXT)
                 .newInstance(template.params + mapOf("ctx" to ctx.asTemplateArg()))
                 .execute()

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/TriggerService.kt
@@ -15,10 +15,13 @@
 
 package com.amazon.opendistroforelasticsearch.alerting
 
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTriggerRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.Alert
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.TraditionalTriggerRunResult
+import com.amazon.opendistroforelasticsearch.alerting.script.AggregationTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TraditionalTriggerExecutionContext
 import com.amazon.opendistroforelasticsearch.alerting.script.TriggerScript
 import org.apache.logging.log4j.LogManager
@@ -47,5 +50,14 @@ class TriggerService(val client: Client, val scriptService: ScriptService) {
             // if the script fails we need to send an alert so set triggered = true
             TraditionalTriggerRunResult(trigger.name, true, e)
         }
+    }
+
+    // TODO: This is a placeholder to write MonitorRunner logic, it can be replaced with the actual implementation when available
+    fun runAggregationTrigger(
+        monitor: Monitor,
+        trigger: AggregationTrigger,
+        ctx: AggregationTriggerExecutionContext
+    ): AggregationTriggerRunResult {
+        return AggregationTriggerRunResult(triggerName = trigger.name, error = null, aggregationResultBuckets = mapOf())
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/TriggerService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/TriggerService.kt
@@ -39,7 +39,11 @@ class TriggerService(val client: Client, val scriptService: ScriptService) {
         return result.triggered && !suppress
     }
 
-    fun runTraditionalTrigger(monitor: Monitor, trigger: TraditionalTrigger, ctx: TraditionalTriggerExecutionContext): TraditionalTriggerRunResult {
+    fun runTraditionalTrigger(
+        monitor: Monitor,
+        trigger: TraditionalTrigger,
+        ctx: TraditionalTriggerExecutionContext
+    ): TraditionalTriggerRunResult {
         return try {
             val triggered = scriptService.compile(trigger.condition, TriggerScript.CONTEXT)
                 .newInstance(trigger.condition.params)

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregationBuilder.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregationBuilder.kt
@@ -251,5 +251,4 @@ class BucketSelectorExtAggregationBuilder :
             return factory
         }
     }
-
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregator.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregator.kt
@@ -46,8 +46,12 @@ class BucketSelectorExtAggregator : SiblingPipelineAggregator {
     private var bucketSelectorExtFilter: BucketSelectorExtFilter? = null
 
     constructor(
-        name: String?, bucketsPathsMap: Map<String, String>, parentBucketPath: String,
-        script: Script, gapPolicy: GapPolicy, filter: BucketSelectorExtFilter?,
+        name: String?,
+        bucketsPathsMap: Map<String, String>,
+        parentBucketPath: String,
+        script: Script,
+        gapPolicy: GapPolicy,
+        filter: BucketSelectorExtFilter?,
         metadata: Map<String, Any>?
     ) : super(name, bucketsPathsMap.values.toTypedArray(), metadata) {
         this.bucketsPathsMap = bucketsPathsMap
@@ -73,7 +77,6 @@ class BucketSelectorExtAggregator : SiblingPipelineAggregator {
             bucketSelectorExtFilter = null
         }
     }
-
 
     @Throws(IOException::class)
     override fun doWriteTo(out: StreamOutput) {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtFilter.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtFilter.kt
@@ -27,10 +27,10 @@ import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude
 import java.io.IOException
 
 class BucketSelectorExtFilter : ToXContentObject, Writeable {
-    val filtersMap // used for composite aggregations
-            : HashMap<String, IncludeExclude>?
-    val filters // used for filtering string term aggregation
-            : IncludeExclude?
+    // used for composite aggregations
+    val filtersMap: HashMap<String, IncludeExclude>?
+    // used for filtering string term aggregation
+    val filters: IncludeExclude?
 
     constructor(filters: IncludeExclude?) {
         filtersMap = null
@@ -100,10 +100,7 @@ class BucketSelectorExtFilter : ToXContentObject, Writeable {
         var BUCKET_SELECTOR_COMPOSITE_AGG_FILTER = ParseField("composite_agg_filter")
 
         @Throws(IOException::class)
-        fun parse(
-            reducerName: String, isCompositeAggregation: Boolean,
-            parser: XContentParser
-        ): BucketSelectorExtFilter {
+        fun parse(reducerName: String, isCompositeAggregation: Boolean, parser: XContentParser): BucketSelectorExtFilter {
             var token: XContentParser.Token
             return if (isCompositeAggregation) {
                 val filtersMap = HashMap<String, IncludeExclude>()

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationResultBucket.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationResultBucket.kt
@@ -30,7 +30,7 @@ data class AggregationResultBucket(
     val parentBucketPath: String?,
     val bucketKeys: List<String>,
     val bucket: Map<String, Any>?
-): Writeable, ToXContent {
+) : Writeable, ToXContent {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(sin.readString(), sin.readStringList(), sin.readMap())

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTriggerRunResult.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AggregationTriggerRunResult.kt
@@ -23,8 +23,8 @@ import java.io.IOException
 data class AggregationTriggerRunResult(
     override var triggerName: String,
     override var error: Exception? = null,
-    var aggregationResultBuckets: Map<String?, AggregationResultBucket>,
-    var actionResultsMap: MutableMap<String?, MutableMap<String, ActionRunResult>> = mutableMapOf()
+    var aggregationResultBuckets: Map<String, AggregationResultBucket>,
+    var actionResultsMap: MutableMap<String, MutableMap<String, ActionRunResult>> = mutableMapOf()
 ) : TriggerRunResult(triggerName, error) {
 
     @Throws(IOException::class)
@@ -33,23 +33,23 @@ data class AggregationTriggerRunResult(
         sin.readString(),
         sin.readException() as Exception?, // error
         sin.readMap(StreamInput::readString, ::AggregationResultBucket),
-        sin.readMap() as MutableMap<String?, MutableMap<String, ActionRunResult>>
+        sin.readMap() as MutableMap<String, MutableMap<String, ActionRunResult>>
     )
 
     override fun internalXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder
             .field(AGG_RESULT_BUCKETS, aggregationResultBuckets)
-            .field(ACTIONS_RESULTS, actionResultsMap as Map<String?, Any>?)
+            .field(ACTIONS_RESULTS, actionResultsMap as Map<String, Any>)
     }
 
     @Throws(IOException::class)
     @Suppress("UNCHECKED_CAST")
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
-        out.writeMap<String?, AggregationResultBucket>(aggregationResultBuckets, StreamOutput::writeString) {
-                valueOut: StreamOutput, aggResultBucket: AggregationResultBucket -> aggResultBucket.writeTo(valueOut)
+        out.writeMap(aggregationResultBuckets, StreamOutput::writeString) {
+            valueOut: StreamOutput, aggResultBucket: AggregationResultBucket -> aggResultBucket.writeTo(valueOut)
         }
-        out.writeMap(actionResultsMap as Map<String, Any>?)
+        out.writeMap(actionResultsMap as Map<String, Any>)
     }
 
     companion object {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
@@ -51,7 +51,7 @@ data class Alert(
     val errorHistory: List<AlertError>,
     val severity: String,
     val actionExecutionResults: List<ActionExecutionResult>,
-    val aggregationResultBucket: AggregationResultBucket?
+    val aggregationResultBucket: AggregationResultBucket? = null
 ) : Writeable, ToXContent {
 
     init {
@@ -189,7 +189,7 @@ data class Alert(
         const val ALERT_HISTORY_FIELD = "alert_history"
         const val SEVERITY_FIELD = "severity"
         const val ACTION_EXECUTION_RESULTS_FIELD = "action_execution_results"
-        const val BUCKET_KEY = AggregationResultBucket.BUCKET_KEY
+        const val BUCKET_KEYS = AggregationResultBucket.BUCKET_KEYS
         const val PARENTS_BUCKET_PATH = AggregationResultBucket.PARENTS_BUCKET_PATH
         const val NO_ID = ""
         const val NO_VERSION = Versions.NOT_FOUND
@@ -302,7 +302,7 @@ data class Alert(
             SEVERITY_FIELD to severity,
             START_TIME_FIELD to startTime.toEpochMilli(),
             STATE_FIELD to state.toString(),
-            BUCKET_KEY to aggregationResultBucket?.bucketKey,
+            BUCKET_KEYS to aggregationResultBucket?.bucketKeys,
             PARENTS_BUCKET_PATH to aggregationResultBucket?.parentBucketPath)
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/MonitorRunResult.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/MonitorRunResult.kt
@@ -28,7 +28,7 @@ import org.elasticsearch.script.ScriptException
 import java.io.IOException
 import java.time.Instant
 
-data class MonitorRunResult<TriggerResult: TriggerRunResult>(
+data class MonitorRunResult<TriggerResult : TriggerRunResult>(
     val monitorName: String,
     val periodStart: Instant,
     val periodEnd: Instant,

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/TraditionalTriggerRunResult.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/TraditionalTriggerRunResult.kt
@@ -23,13 +23,12 @@ import org.elasticsearch.script.ScriptException
 import java.io.IOException
 import java.time.Instant
 
-data class TraditionalTriggerRunResult (
+data class TraditionalTriggerRunResult(
     override var triggerName: String,
     var triggered: Boolean,
     override var error: Exception?,
     var actionResults: MutableMap<String, ActionRunResult> = mutableMapOf()
 ) : TriggerRunResult(triggerName, error) {
-
 
     @Throws(IOException::class)
     @Suppress("UNCHECKED_CAST")

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/AggregationTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/AggregationTriggerExecutionContext.kt
@@ -32,7 +32,7 @@ data class AggregationTriggerExecutionContext(
     val newAlerts: List<Alert> = listOf(),
     val completedAlerts: List<Alert> = listOf(),
     override val error: Exception? = null
-): TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
+) : TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
 
     constructor(
         monitor: Monitor,

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/AggregationTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/AggregationTriggerExecutionContext.kt
@@ -28,14 +28,21 @@ data class AggregationTriggerExecutionContext(
     override val results: List<Map<String, Any>>,
     override val periodStart: Instant,
     override val periodEnd: Instant,
-    val alerts: HashMap<String?, Alert>? = null,
+    val dedupedAlerts: List<Alert> = listOf(),
+    val newAlerts: List<Alert> = listOf(),
+    val completedAlerts: List<Alert> = listOf(),
     override val error: Exception? = null
 ): TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
 
-    constructor(monitor: Monitor, trigger: AggregationTrigger, monitorRunResult: MonitorRunResult<AggregationTriggerRunResult>,
-                alerts: HashMap<String?, Alert>? = null):
-            this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart,
-            monitorRunResult.periodEnd, alerts, monitorRunResult.scriptContextError(trigger))
+    constructor(
+        monitor: Monitor,
+        trigger: AggregationTrigger,
+        monitorRunResult: MonitorRunResult<AggregationTriggerRunResult>,
+        dedupedAlerts: List<Alert> = listOf(),
+        newAlerts: List<Alert> = listOf(),
+        completedAlerts: List<Alert> = listOf()
+    ) : this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart, monitorRunResult.periodEnd,
+        dedupedAlerts, newAlerts, completedAlerts, monitorRunResult.scriptContextError(trigger))
 
     /**
      * Mustache templates need special permissions to reflectively introspect field names. To avoid doing this we
@@ -44,7 +51,9 @@ data class AggregationTriggerExecutionContext(
     override fun asTemplateArg(): Map<String, Any?> {
         val tempArg = super.asTemplateArg().toMutableMap()
         tempArg["trigger"] = trigger.asTemplateArg()
-        tempArg["alerts"] = alerts?.map { it.key to it.value.asTemplateArg() }
+        tempArg["dedupedAlerts"] = dedupedAlerts.map { it.asTemplateArg() }
+        tempArg["newAlerts"] = newAlerts.map { it.asTemplateArg() }
+        tempArg["completedAlerts"] = completedAlerts.map { it.asTemplateArg() }
         return tempArg
     }
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/TraditionalTriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/TraditionalTriggerExecutionContext.kt
@@ -32,10 +32,13 @@ data class TraditionalTriggerExecutionContext(
     override val error: Exception? = null
 ) : TriggerExecutionContext(monitor, results, periodStart, periodEnd, error) {
 
-    constructor(monitor: Monitor, trigger: TraditionalTrigger, monitorRunResult: MonitorRunResult<TraditionalTriggerRunResult>,
-                alert: Alert? = null):
-            this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart,
-            monitorRunResult.periodEnd, alert, monitorRunResult.scriptContextError(trigger))
+    constructor(
+        monitor: Monitor,
+        trigger: TraditionalTrigger,
+        monitorRunResult: MonitorRunResult<TraditionalTriggerRunResult>,
+        alert: Alert? = null
+    ) : this(monitor, trigger, monitorRunResult.inputResults.results, monitorRunResult.periodStart, monitorRunResult.periodEnd,
+        alert, monitorRunResult.scriptContextError(trigger))
 
     /**
      * Mustache templates need special permissions to reflectively introspect field names. To avoid doing this we

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/TriggerExecutionContext.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/script/TriggerExecutionContext.kt
@@ -19,13 +19,13 @@ import com.amazon.opendistroforelasticsearch.alerting.model.MonitorRunResult
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
 import java.time.Instant
 
-abstract class TriggerExecutionContext (
+abstract class TriggerExecutionContext(
     open val monitor: Monitor,
     open val results: List<Map<String, Any>>,
     open val periodStart: Instant,
     open val periodEnd: Instant,
     open val error: Exception? = null
-    ) {
+) {
 
     constructor(monitor: Monitor, trigger: Trigger, monitorRunResult: MonitorRunResult<*>):
         this(monitor, monitorRunResult.inputResults.results, monitorRunResult.periodStart,

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AlertingUtils.kt
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.alerting.util
 
 import com.amazon.opendistroforelasticsearch.alerting.destination.message.BaseMessage
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationResultBucket
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.Destination
 import com.amazon.opendistroforelasticsearch.alerting.settings.DestinationSettings
@@ -121,3 +122,9 @@ fun <T : Any> checkUserFilterByPermissions(
 }
 
 fun Monitor.isAggregationMonitor(): Boolean = this.monitorType == Monitor.MonitorType.AGGREGATION_MONITOR
+
+/**
+ * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used
+ * as the key for a HashMap to easily retrieve [AggregationResultBucket] based on the bucket key values.
+ */
+fun AggregationResultBucket.getBucketKeysHash(): String = this.bucketKeys.joinToString(separator = "#")

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertServiceTests.kt
@@ -1,0 +1,180 @@
+/*
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.alerting
+
+import com.amazon.opendistroforelasticsearch.alerting.alerts.AlertIndices
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationResultBucket
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
+import com.amazon.opendistroforelasticsearch.alerting.model.Alert
+import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.alerting.settings.AlertingSettings
+import com.amazon.opendistroforelasticsearch.alerting.util.getBucketKeysHash
+import org.elasticsearch.Version
+import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.node.DiscoveryNode
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.settings.ClusterSettings
+import org.elasticsearch.common.settings.Setting
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.test.ClusterServiceUtils
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.threadpool.ThreadPool
+import org.junit.Before
+import org.mockito.Mockito
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class AlertServiceTests : ESTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var xContentRegistry: NamedXContentRegistry
+    private lateinit var settings: Settings
+    private lateinit var threadPool: ThreadPool
+    private lateinit var clusterService: ClusterService
+
+    private lateinit var alertIndices: AlertIndices
+    private lateinit var alertService: AlertService
+
+    @Before
+    fun setup() {
+        // TODO: If more *Service unit tests are added, this configuration can be moved to some base class for each service test class to use
+        client = Mockito.mock(Client::class.java)
+        xContentRegistry = Mockito.mock(NamedXContentRegistry::class.java)
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+
+        settings = Settings.builder().build()
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_ENABLED)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_MAX_DOCS)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_INDEX_MAX_AGE)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_ROLLOVER_PERIOD)
+        settingSet.add(AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD)
+        settingSet.add(AlertingSettings.REQUEST_TIMEOUT)
+        val discoveryNode = DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT)
+        val clusterSettings = ClusterSettings(settings, settingSet)
+        val testClusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings)
+        clusterService = Mockito.spy(testClusterService)
+
+        alertIndices = AlertIndices(settings, client, threadPool, clusterService)
+        alertService = AlertService(client, xContentRegistry, alertIndices)
+    }
+
+    fun `test getting categorized alerts for aggregation monitor with no current alerts`() {
+        val trigger = randomAggregationTrigger()
+        val monitor = randomAggregationMonitor(triggers = listOf(trigger))
+
+        val currentAlerts = null
+        val aggResultBuckets = createAggregationResultBucketsFromBucketKeys(listOf(
+            listOf("a"),
+            listOf("b")
+        ))
+
+        val categorizedAlerts = alertService.getCategorizedAlertsForAggregationMonitor(monitor, trigger, currentAlerts, aggResultBuckets)
+        assertEquals(listOf<Alert>(), categorizedAlerts.dedupedAlerts)
+        assertAlertsExistForBucketKeys(listOf(
+            listOf("a"),
+            listOf("b")
+        ), categorizedAlerts.newAlerts)
+        assertEquals(listOf<Alert>(), categorizedAlerts.completedAlerts)
+    }
+
+    fun `test getting categorized alerts for aggregation monitor with de-duped alerts`() {
+        val trigger = randomAggregationTrigger()
+        val monitor = randomAggregationMonitor(triggers = listOf(trigger))
+
+        val currentAlerts = createCurrentAlertsFromBucketKeys(monitor, trigger, listOf(
+            listOf("a"),
+            listOf("b")
+        ))
+        val aggResultBuckets = createAggregationResultBucketsFromBucketKeys(listOf(
+            listOf("a"),
+            listOf("b")
+        ))
+
+        val categorizedAlerts = alertService.getCategorizedAlertsForAggregationMonitor(monitor, trigger, currentAlerts, aggResultBuckets)
+        assertAlertsExistForBucketKeys(listOf(
+            listOf("a"),
+            listOf("b")
+        ), categorizedAlerts.dedupedAlerts)
+        assertEquals(listOf<Alert>(), categorizedAlerts.newAlerts)
+        assertEquals(listOf<Alert>(), categorizedAlerts.completedAlerts)
+    }
+
+    fun `test getting categorized alerts for aggregation monitor with completed alerts`() {
+        val trigger = randomAggregationTrigger()
+        val monitor = randomAggregationMonitor(triggers = listOf(trigger))
+
+        val currentAlerts = createCurrentAlertsFromBucketKeys(monitor, trigger, listOf(
+            listOf("a"),
+            listOf("b")
+        ))
+        val aggResultBuckets = listOf<AggregationResultBucket>()
+
+        val categorizedAlerts = alertService.getCategorizedAlertsForAggregationMonitor(monitor, trigger, currentAlerts, aggResultBuckets)
+        assertEquals(listOf<Alert>(), categorizedAlerts.dedupedAlerts)
+        assertEquals(listOf<Alert>(), categorizedAlerts.newAlerts)
+        assertAlertsExistForBucketKeys(listOf(
+            listOf("a"),
+            listOf("b")
+        ), categorizedAlerts.completedAlerts)
+    }
+
+    fun `test getting categorized alerts for aggregation monitor with de-duped and completed alerts`() {
+        val trigger = randomAggregationTrigger()
+        val monitor = randomAggregationMonitor(triggers = listOf(trigger))
+
+        val currentAlerts = createCurrentAlertsFromBucketKeys(monitor, trigger, listOf(
+            listOf("a"),
+            listOf("b")
+        ))
+        val aggResultBuckets = createAggregationResultBucketsFromBucketKeys(listOf(
+            listOf("b"),
+            listOf("c")
+        ))
+
+        val categorizedAlerts = alertService.getCategorizedAlertsForAggregationMonitor(monitor, trigger, currentAlerts, aggResultBuckets)
+        assertAlertsExistForBucketKeys(listOf(listOf("b")), categorizedAlerts.dedupedAlerts)
+        assertAlertsExistForBucketKeys(listOf(listOf("c")), categorizedAlerts.newAlerts)
+        assertAlertsExistForBucketKeys(listOf(listOf("a")), categorizedAlerts.completedAlerts)
+    }
+
+    private fun createCurrentAlertsFromBucketKeys(monitor: Monitor, trigger: AggregationTrigger, bucketKeysList: List<List<String>>): Map<String, Alert> {
+        return bucketKeysList.map { bucketKeys ->
+            val aggResultBucket = AggregationResultBucket("parent_bucket_path", bucketKeys, mapOf())
+            val alert = Alert(monitor, trigger, Instant.now().truncatedTo(ChronoUnit.MILLIS), null,
+                actionExecutionResults = listOf(randomActionExecutionResult()), aggregationResultBucket = aggResultBucket)
+            aggResultBucket.getBucketKeysHash() to alert
+        }.toMap()
+    }
+
+    private fun createAggregationResultBucketsFromBucketKeys(bucketKeysList: List<List<String>>): List<AggregationResultBucket> {
+        return bucketKeysList.map { AggregationResultBucket("parent_bucket_path", it, mapOf()) }
+    }
+
+    private fun assertAlertsExistForBucketKeys(bucketKeysList: List<List<String>>, alerts: List<Alert>) {
+        // Check if size is equals first for sanity and since bucketKeysList should have unique entries,
+        // this ensures there shouldn't be duplicates in the alerts
+        assertEquals(bucketKeysList.size, alerts.size)
+        val expectedBucketKeyHashes = bucketKeysList.map { it.joinToString(separator = "#") }.toSet()
+        alerts.forEach { alert ->
+            assertNotNull(alert.aggregationResultBucket)
+            assertTrue(expectedBucketKeyHashes.contains(alert.aggregationResultBucket!!.getBucketKeysHash()))
+        }
+    }
+}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertServiceTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/AlertServiceTests.kt
@@ -154,7 +154,11 @@ class AlertServiceTests : ESTestCase() {
         assertAlertsExistForBucketKeys(listOf(listOf("a")), categorizedAlerts.completedAlerts)
     }
 
-    private fun createCurrentAlertsFromBucketKeys(monitor: Monitor, trigger: AggregationTrigger, bucketKeysList: List<List<String>>): Map<String, Alert> {
+    private fun createCurrentAlertsFromBucketKeys(
+        monitor: Monitor,
+        trigger: AggregationTrigger,
+        bucketKeysList: List<List<String>>
+    ): Map<String, Alert> {
         return bucketKeysList.map { bucketKeys ->
             val aggResultBucket = AggregationResultBucket("parent_bucket_path", bucketKeys, mapOf())
             val alert = Alert(monitor, trigger, Instant.now().truncatedTo(ChronoUnit.MILLIS), null,

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -38,6 +38,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.action.Throttle
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.EmailAccount
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.EmailEntry
 import com.amazon.opendistroforelasticsearch.alerting.model.destination.email.EmailGroup
+import com.amazon.opendistroforelasticsearch.alerting.util.getBucketKeysHash
 import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import org.apache.http.Header
 import org.apache.http.HttpEntity
@@ -97,6 +98,22 @@ fun randomMonitorWithoutUser(
 ): Monitor {
     return Monitor(name = name, monitorType = Monitor.MonitorType.TRADITIONAL_MONITOR, enabled = enabled, inputs = inputs,
         schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = null,
+        uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
+}
+
+fun randomAggregationMonitor(
+    name: String = ESRestTestCase.randomAlphaOfLength(10),
+    user: User = randomUser(),
+    inputs: List<Input> = listOf(SearchInput(emptyList(), SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))),
+    schedule: Schedule = IntervalSchedule(interval = 5, unit = ChronoUnit.MINUTES),
+    enabled: Boolean = ESTestCase.randomBoolean(),
+    triggers: List<Trigger> = (1..randomInt(10)).map { randomAggregationTrigger() },
+    enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
+    lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+    withMetadata: Boolean = false
+): Monitor {
+    return Monitor(name = name, monitorType = Monitor.MonitorType.AGGREGATION_MONITOR, enabled = enabled, inputs = inputs,
+        schedule = schedule, triggers = triggers, enabledTime = enabledTime, lastUpdateTime = lastUpdateTime, user = user,
         uiMetadata = if (withMetadata) mapOf("foo" to "bar") else mapOf())
 }
 
@@ -213,8 +230,8 @@ fun randomAlertWithAggregationResultBucket(monitor: Monitor = randomMonitor()): 
     val trigger = randomAggregationTrigger()
     val actionExecutionResults = mutableListOf(randomActionExecutionResult(), randomActionExecutionResult())
     return Alert(monitor, trigger, Instant.now().truncatedTo(ChronoUnit.MILLIS), null,
-        actionExecutionResults = actionExecutionResults, aggregationResultBucket = AggregationResultBucket("parent_bucket_path_1", "bucket_key_1",
-            mapOf("k1" to "val1", "k2" to "val2")))
+        actionExecutionResults = actionExecutionResults, aggregationResultBucket = AggregationResultBucket("parent_bucket_path_1",
+        listOf("bucket_key_1"), mapOf("k1" to "val1", "k2" to "val2")))
 }
 
 fun randomEmailAccountMethod(): EmailAccount.MethodType {
@@ -275,17 +292,17 @@ fun randomAggregationTriggerRunResult(): AggregationTriggerRunResult {
     map.plus(Pair("key1", randomActionRunResult()))
     map.plus(Pair("key2", randomActionRunResult()))
 
-    val aggBcuket1 = AggregationResultBucket("parent_bucket_path_1", "bucket_key_1",
+    val aggBucket1 = AggregationResultBucket("parent_bucket_path_1", listOf("bucket_key_1"),
         mapOf("k1" to "val1", "k2" to "val2"))
-    val aggBcuket2 = AggregationResultBucket("parent_bucket_path_2", "bucket_key_2",
+    val aggBucket2 = AggregationResultBucket("parent_bucket_path_2", listOf("bucket_key_2"),
         mapOf("k1" to "val1", "k2" to "val2"))
 
     val actionResultsMap: MutableMap<String?, MutableMap<String, ActionRunResult>> = mutableMapOf()
-    actionResultsMap[aggBcuket1.bucketKey] = map
-    actionResultsMap[aggBcuket2.bucketKey] = map
+    actionResultsMap[aggBucket1.getBucketKeysHash()] = map
+    actionResultsMap[aggBucket2.getBucketKeysHash()] = map
 
     return AggregationTriggerRunResult("trigger-name", null,
-        mapOf(aggBcuket1.bucketKey to aggBcuket1, aggBcuket2.bucketKey to aggBcuket2), actionResultsMap)
+        mapOf(aggBucket1.getBucketKeysHash() to aggBucket1, aggBucket2.getBucketKeysHash() to aggBucket2), actionResultsMap)
 }
 
 fun randomActionRunResult(): ActionRunResult {

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/TestHelpers.kt
@@ -152,10 +152,10 @@ fun randomAggregationTrigger(
 fun randomBucketSelectorExtAggregationBuilder(
     name: String = ESRestTestCase.randomAlphaOfLength(10),
     bucketsPathsMap: MutableMap<String, String> = mutableMapOf("avg" to "10"),
-    script: Script = randomBucketSelectorScript(params=bucketsPathsMap),
+    script: Script = randomBucketSelectorScript(params = bucketsPathsMap),
     parentBucketPath: String = "testPath",
     filter: BucketSelectorExtFilter = BucketSelectorExtFilter(IncludeExclude("foo*", "bar*"))
-    ) : BucketSelectorExtAggregationBuilder {
+): BucketSelectorExtAggregationBuilder {
     return BucketSelectorExtAggregationBuilder(name, bucketsPathsMap, script, parentBucketPath, filter)
 }
 
@@ -297,7 +297,7 @@ fun randomAggregationTriggerRunResult(): AggregationTriggerRunResult {
     val aggBucket2 = AggregationResultBucket("parent_bucket_path_2", listOf("bucket_key_2"),
         mapOf("k1" to "val1", "k2" to "val2"))
 
-    val actionResultsMap: MutableMap<String?, MutableMap<String, ActionRunResult>> = mutableMapOf()
+    val actionResultsMap: MutableMap<String, MutableMap<String, ActionRunResult>> = mutableMapOf()
     actionResultsMap[aggBucket1.getBucketKeysHash()] = map
     actionResultsMap[aggBucket2.getBucketKeysHash()] = map
 

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregatorTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregatorTests.kt
@@ -332,9 +332,11 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
 
     @Throws(IOException::class)
     private fun testCase(
-        aggregationBuilder: FiltersAggregationBuilder, query: Query,
+        aggregationBuilder: FiltersAggregationBuilder,
+        query: Query,
         buildIndex: CheckedConsumer<RandomIndexWriter, IOException>,
-        verify: Consumer<InternalFilters>, vararg fieldType: MappedFieldType
+        verify: Consumer<InternalFilters>,
+        vararg fieldType: MappedFieldType
     ) {
         newDirectory().use { directory ->
             val indexWriter = RandomIndexWriter(random(), directory)
@@ -351,9 +353,11 @@ class BucketSelectorExtAggregatorTests : AggregatorTestCase() {
 
     @Throws(IOException::class)
     private fun testCaseInternalFilter(
-        aggregationBuilder: FilterAggregationBuilder, query: Query,
+        aggregationBuilder: FilterAggregationBuilder,
+        query: Query,
         buildIndex: CheckedConsumer<RandomIndexWriter, IOException>,
-        verify: Consumer<InternalFilter>, vararg fieldType: MappedFieldType
+        verify: Consumer<InternalFilter>,
+        vararg fieldType: MappedFieldType
     ) {
         newDirectory().use { directory ->
             val indexWriter = RandomIndexWriter(random(), directory)

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AlertTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AlertTests.kt
@@ -51,9 +51,10 @@ class AlertTests : ESTestCase() {
         assertEquals("Template args start time does not", templateArgs[Alert.START_TIME_FIELD], alert.startTime.toEpochMilli())
         assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
         assertEquals("Template args severity does not match", templateArgs[Alert.SEVERITY_FIELD], alert.severity)
-        Assert.assertEquals("Template args bucketKeys do not match", templateArgs[Alert.BUCKET_KEYS], alert.aggregationResultBucket?.bucketKeys)
-        Assert.assertEquals("Template args parentBucketPath does not match", templateArgs[Alert.PARENTS_BUCKET_PATH], alert.aggregationResultBucket?.parentBucketPath)
-
+        Assert.assertEquals("Template args bucketKeys do not match",
+            templateArgs[Alert.BUCKET_KEYS], alert.aggregationResultBucket?.bucketKeys)
+        Assert.assertEquals("Template args parentBucketPath does not match",
+            templateArgs[Alert.PARENTS_BUCKET_PATH], alert.aggregationResultBucket?.parentBucketPath)
     }
     fun `test alert acknowledged`() {
         val ackAlert = randomAlert().copy(state = Alert.State.ACKNOWLEDGED)

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AlertTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/AlertTests.kt
@@ -51,7 +51,7 @@ class AlertTests : ESTestCase() {
         assertEquals("Template args start time does not", templateArgs[Alert.START_TIME_FIELD], alert.startTime.toEpochMilli())
         assertEquals("Template args last notification time does not match", templateArgs[Alert.LAST_NOTIFICATION_TIME_FIELD], null)
         assertEquals("Template args severity does not match", templateArgs[Alert.SEVERITY_FIELD], alert.severity)
-        Assert.assertEquals("Template args bucketKey does not match", templateArgs[Alert.BUCKET_KEY], alert.aggregationResultBucket?.bucketKey)
+        Assert.assertEquals("Template args bucketKeys do not match", templateArgs[Alert.BUCKET_KEYS], alert.aggregationResultBucket?.bucketKeys)
         Assert.assertEquals("Template args parentBucketPath does not match", templateArgs[Alert.PARENTS_BUCKET_PATH], alert.aggregationResultBucket?.parentBucketPath)
 
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adds method to categorize Alerts for Aggregation Monitor in AlertService
* Adds initial MonitorRunner change to take categorized Alerts, populate Trigger context and execute Actions
* Adds AlertService unit tests
* Some minor formatting changes

The MonitorRunner logic for the Aggregation Monitor is in a bit of a transitive state at the moment. It will be cleaned up on subsequent PRs but has been included to show the general flow of the Alert creation and Action execution.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
