### PR TITLE
Query rewriter for aggregation monitor

### DIFF
--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/InputService.kt
@@ -18,8 +18,10 @@ package com.amazon.opendistroforelasticsearch.alerting
 import com.amazon.opendistroforelasticsearch.alerting.core.model.SearchInput
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.convertToMap
 import com.amazon.opendistroforelasticsearch.alerting.elasticapi.suspendUntil
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.InputRunResults
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
 import com.amazon.opendistroforelasticsearch.alerting.util.addUserBackendRolesFilter
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.search.SearchRequest
@@ -32,6 +34,12 @@ import org.elasticsearch.script.Script
 import org.elasticsearch.script.ScriptService
 import org.elasticsearch.script.ScriptType
 import org.elasticsearch.script.TemplateScript
+import org.elasticsearch.search.aggregations.AggregationBuilder
+import org.elasticsearch.search.aggregations.AggregatorFactories
+import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite
+import org.elasticsearch.search.aggregations.support.AggregationPath
 import org.elasticsearch.search.builder.SearchSourceBuilder
 import java.time.Instant
 
@@ -44,15 +52,19 @@ class InputService(
 
     private val logger = LogManager.getLogger(InputService::class.java)
 
-    suspend fun collectInputResults(monitor: Monitor, periodStart: Instant, periodEnd: Instant): InputRunResults {
+    suspend fun collectInputResults(monitor: Monitor, periodStart: Instant, periodEnd: Instant, prevResult: InputRunResults? = null): InputRunResults {
         return try {
             val results = mutableListOf<Map<String, Any>>()
+            val aggTriggerAfterKeys: MutableMap<String, Map<String, Any>?> = mutableMapOf()
+
             monitor.inputs.forEach { input ->
                 when (input) {
                     is SearchInput -> {
                         // TODO: Figure out a way to use SearchTemplateRequest without bringing in the entire TransportClient
                         val searchParams = mapOf("period_start" to periodStart.toEpochMilli(),
                             "period_end" to periodEnd.toEpochMilli())
+                        rewriteQuery(input.query, prevResult, monitor.triggers)
+
                         val searchSource = scriptService.compile(Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG,
                             input.query.toString(), searchParams), TemplateScript.CONTEXT)
                             .newInstance(searchParams)
@@ -63,6 +75,7 @@ class InputService(
                             searchRequest.source(SearchSourceBuilder.fromXContent(it))
                         }
                         val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
+                        aggTriggerAfterKeys += getAfterKeysFromSearchResponse(searchResponse, monitor.triggers)
                         results += searchResponse.convertToMap()
                     }
                     else -> {
@@ -70,7 +83,7 @@ class InputService(
                     }
                 }
             }
-            InputRunResults(results.toList())
+            InputRunResults(results.toList(), aggTriggersAfterKey = aggTriggerAfterKeys)
         } catch (e: Exception) {
             logger.info("Error collecting inputs for monitor: ${monitor.id}", e)
             InputRunResults(emptyList(), e)
@@ -131,4 +144,54 @@ class InputService(
             InputRunResults(emptyList(), e)
         }
     }
+}
+
+fun rewriteQuery(query: SearchSourceBuilder, prevResult: InputRunResults?, triggers: List<Trigger>) {
+    triggers.forEach { trigger ->
+        if (trigger is AggregationTrigger) {
+            query.aggregation(trigger.bucketSelector)
+            if (prevResult?.aggTriggersAfterKey?.keys?.contains(trigger.id) == true) {
+                val parentBucketPath = AggregationPath.parse(trigger.bucketSelector.parentBucketPath)
+                var aggBuilders = (query.aggregations() as AggregatorFactories.Builder).aggregatorFactories
+                var factory: AggregationBuilder? = null
+                for (i in 0 until parentBucketPath.pathElements.size) {
+                    factory = null
+                    for (aggFactory in aggBuilders) {
+                        if (aggFactory.name.equals(parentBucketPath.pathElements[i].name)) {
+                            aggBuilders = aggFactory.subAggregations
+                            factory = aggFactory
+                            break
+                        }
+                    }
+                    if (factory == null) {
+                        throw IllegalArgumentException("ParentBucketPath: $parentBucketPath not found in input query results")
+                    }
+                }
+                if (factory is CompositeAggregationBuilder) {
+                    // if the afterKey from previous result is null, what does it signify?
+                    // A) result set exhausted OR  B) first page ?
+                    val afterKey = prevResult.aggTriggersAfterKey[trigger.id]
+                    factory.aggregateAfter(afterKey)
+                }
+            }
+        }
+    }
+}
+
+fun getAfterKeysFromSearchResponse(searchResponse: SearchResponse, triggers: List<Trigger>): Map<String, Map<String, Any>?> {
+    val aggTriggerAfterKeys = mutableMapOf<String, Map<String, Any>?>()
+    triggers.forEach { trigger ->
+        if (trigger is AggregationTrigger) {
+            val parentBucketPath = AggregationPath.parse(trigger.bucketSelector.parentBucketPath)
+            var aggs = searchResponse.aggregations
+            for (i in 0 until parentBucketPath.pathElements.size - 1) {
+                aggs = (aggs.asMap()[parentBucketPath.pathElements[i].name] as SingleBucketAggregation).aggregations
+            }
+            val lastAgg = aggs.asMap[parentBucketPath.pathElements.last().name]
+            if (lastAgg is InternalComposite) {
+                aggTriggerAfterKeys[trigger.id] = lastAgg.afterKey()
+            }
+        }
+    }
+    return aggTriggerAfterKeys
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/InputService.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/InputService.kt
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
 import com.amazon.opendistroforelasticsearch.alerting.model.InputRunResults
 import com.amazon.opendistroforelasticsearch.alerting.model.Monitor
 import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.alerting.util.AggregationQueryRewriter
 import com.amazon.opendistroforelasticsearch.alerting.util.addUserBackendRolesFilter
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.search.SearchRequest
@@ -63,8 +64,7 @@ class InputService(
                         // TODO: Figure out a way to use SearchTemplateRequest without bringing in the entire TransportClient
                         val searchParams = mapOf("period_start" to periodStart.toEpochMilli(),
                             "period_end" to periodEnd.toEpochMilli())
-                        rewriteQuery(input.query, prevResult, monitor.triggers)
-
+                        AggregationQueryRewriter.rewriteQuery(input.query, prevResult, monitor.triggers)
                         val searchSource = scriptService.compile(Script(ScriptType.INLINE, Script.DEFAULT_TEMPLATE_LANG,
                             input.query.toString(), searchParams), TemplateScript.CONTEXT)
                             .newInstance(searchParams)
@@ -75,7 +75,7 @@ class InputService(
                             searchRequest.source(SearchSourceBuilder.fromXContent(it))
                         }
                         val searchResponse: SearchResponse = client.suspendUntil { client.search(searchRequest, it) }
-                        aggTriggerAfterKeys += getAfterKeysFromSearchResponse(searchResponse, monitor.triggers)
+                        aggTriggerAfterKeys += AggregationQueryRewriter.getAfterKeysFromSearchResponse(searchResponse, monitor.triggers)
                         results += searchResponse.convertToMap()
                     }
                     else -> {
@@ -144,54 +144,4 @@ class InputService(
             InputRunResults(emptyList(), e)
         }
     }
-}
-
-fun rewriteQuery(query: SearchSourceBuilder, prevResult: InputRunResults?, triggers: List<Trigger>) {
-    triggers.forEach { trigger ->
-        if (trigger is AggregationTrigger) {
-            query.aggregation(trigger.bucketSelector)
-            if (prevResult?.aggTriggersAfterKey?.keys?.contains(trigger.id) == true) {
-                val parentBucketPath = AggregationPath.parse(trigger.bucketSelector.parentBucketPath)
-                var aggBuilders = (query.aggregations() as AggregatorFactories.Builder).aggregatorFactories
-                var factory: AggregationBuilder? = null
-                for (i in 0 until parentBucketPath.pathElements.size) {
-                    factory = null
-                    for (aggFactory in aggBuilders) {
-                        if (aggFactory.name.equals(parentBucketPath.pathElements[i].name)) {
-                            aggBuilders = aggFactory.subAggregations
-                            factory = aggFactory
-                            break
-                        }
-                    }
-                    if (factory == null) {
-                        throw IllegalArgumentException("ParentBucketPath: $parentBucketPath not found in input query results")
-                    }
-                }
-                if (factory is CompositeAggregationBuilder) {
-                    // if the afterKey from previous result is null, what does it signify?
-                    // A) result set exhausted OR  B) first page ?
-                    val afterKey = prevResult.aggTriggersAfterKey[trigger.id]
-                    factory.aggregateAfter(afterKey)
-                }
-            }
-        }
-    }
-}
-
-fun getAfterKeysFromSearchResponse(searchResponse: SearchResponse, triggers: List<Trigger>): Map<String, Map<String, Any>?> {
-    val aggTriggerAfterKeys = mutableMapOf<String, Map<String, Any>?>()
-    triggers.forEach { trigger ->
-        if (trigger is AggregationTrigger) {
-            val parentBucketPath = AggregationPath.parse(trigger.bucketSelector.parentBucketPath)
-            var aggs = searchResponse.aggregations
-            for (i in 0 until parentBucketPath.pathElements.size - 1) {
-                aggs = (aggs.asMap()[parentBucketPath.pathElements[i].name] as SingleBucketAggregation).aggregations
-            }
-            val lastAgg = aggs.asMap[parentBucketPath.pathElements.last().name]
-            if (lastAgg is InternalComposite) {
-                aggTriggerAfterKeys[trigger.id] = lastAgg.afterKey()
-            }
-        }
-    }
-    return aggTriggerAfterKeys
 }

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/Alert.kt
@@ -213,7 +213,7 @@ data class Alert(
             var acknowledgedTime: Instant? = null
             var errorMessage: String? = null
             val errorHistory: MutableList<AlertError> = mutableListOf()
-            var actionExecutionResults: MutableList<ActionExecutionResult> = mutableListOf()
+            val actionExecutionResults: MutableList<ActionExecutionResult> = mutableListOf()
             var aggAlertBucket: AggregationResultBucket? = null
             ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/MonitorRunResult.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/model/MonitorRunResult.kt
@@ -99,7 +99,11 @@ data class MonitorRunResult<TriggerResult : TriggerRunResult>(
     }
 }
 
-data class InputRunResults(val results: List<Map<String, Any>> = listOf(), val error: Exception? = null) : Writeable, ToXContent {
+data class InputRunResults(
+    val results: List<Map<String, Any>> = listOf(),
+    val error: Exception? = null,
+    val aggTriggersAfterKey: MutableMap<String, Map<String, Any>?>? = null
+) : Writeable, ToXContent {
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         return builder.startObject()
@@ -133,6 +137,15 @@ data class InputRunResults(val results: List<Map<String, Any>> = listOf(), val e
         fun suppressWarning(map: MutableMap<String?, Any?>?): Map<String, Any> {
             return map as Map<String, Any>
         }
+    }
+
+    fun afterKeysPresent(): Boolean {
+        aggTriggersAfterKey?.forEach {
+            if (it.value != null) {
+                return true
+            }
+        }
+        return false
     }
 }
 

--- a/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AggregationQueryRewriter.kt
+++ b/alerting/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AggregationQueryRewriter.kt
@@ -1,0 +1,82 @@
+package com.amazon.opendistroforelasticsearch.alerting.util
+
+import com.amazon.opendistroforelasticsearch.alerting.model.AggregationTrigger
+import com.amazon.opendistroforelasticsearch.alerting.model.InputRunResults
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.search.aggregations.AggregationBuilder
+import org.elasticsearch.search.aggregations.AggregatorFactories
+import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder
+import org.elasticsearch.search.aggregations.support.AggregationPath
+import org.elasticsearch.search.builder.SearchSourceBuilder
+
+class AggregationQueryRewriter {
+
+    companion object {
+        /**
+         * Add the bucket selector conditions for each trigger in input query. It also adds afterKeys from previous result
+         * for each trigger.
+         */
+        fun rewriteQuery(query: SearchSourceBuilder, prevResult: InputRunResults?, triggers: List<Trigger>) {
+            triggers.forEach { trigger ->
+                if (trigger is AggregationTrigger) {
+                    // add bucket selector pipeline aggregation for each trigger in query
+                    query.aggregation(trigger.bucketSelector)
+                    // if this request is processing the subsequent pages of input query result, then add after key
+                    if (prevResult?.aggTriggersAfterKey?.get(trigger.id) != null) {
+                        val parentBucketPath = AggregationPath.parse(trigger.bucketSelector.parentBucketPath)
+                        var aggBuilders = (query.aggregations() as AggregatorFactories.Builder).aggregatorFactories
+                        var factory: AggregationBuilder? = null
+                        for (i in 0 until parentBucketPath.pathElements.size) {
+                            factory = null
+                            for (aggFactory in aggBuilders) {
+                                if (aggFactory.name.equals(parentBucketPath.pathElements[i].name)) {
+                                    aggBuilders = aggFactory.subAggregations
+                                    factory = aggFactory
+                                    break
+                                }
+                            }
+                            if (factory == null) {
+                                throw IllegalArgumentException("ParentBucketPath: $parentBucketPath not found in input query results")
+                            }
+                        }
+                        if (factory is CompositeAggregationBuilder) {
+                            // if the afterKey from previous result is null, what does it signify?
+                            // A) result set exhausted OR  B) first page ?
+                            val afterKey = prevResult.aggTriggersAfterKey[trigger.id]
+                            factory.aggregateAfter(afterKey)
+                        } else {
+                            throw IllegalStateException("AfterKeys are not expected to be present in non CompositeAggregationBuilder")
+
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * For each trigger, returns the after keys if present in query result.
+         */
+        fun getAfterKeysFromSearchResponse(searchResponse: SearchResponse, triggers: List<Trigger>): Map<String, Map<String, Any>?> {
+            val aggTriggerAfterKeys = mutableMapOf<String, Map<String, Any>?>()
+            triggers.forEach { trigger ->
+                if (trigger is AggregationTrigger) {
+                    val parentBucketPath = AggregationPath.parse(trigger.bucketSelector.parentBucketPath)
+                    var aggs = searchResponse.aggregations
+                    // assuming all intermediate aggregations as SingleBucketAggregation
+                    for (i in 0 until parentBucketPath.pathElements.size - 1) {
+                        aggs = (aggs.asMap()[parentBucketPath.pathElements[i].name] as SingleBucketAggregation).aggregations
+                    }
+                    val lastAgg = aggs.asMap[parentBucketPath.pathElements.last().name]
+                    // if leaf is CompositeAggregation, then fetch afterKey if present
+                    if (lastAgg is CompositeAggregation) {
+                        aggTriggerAfterKeys[trigger.id] = lastAgg.afterKey()
+                    }
+                }
+            }
+            return aggTriggerAfterKeys
+        }
+    }
+}

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/alerts/AlertIndicesIT.kt
@@ -166,7 +166,7 @@ class AlertIndicesIT : AlertingRestTestCase() {
         client().updateSettings(AlertingSettings.ALERT_HISTORY_RETENTION_PERIOD.key, "1s")
 
         // Give some time for history to be rolled over and cleared
-        Thread.sleep(2000)
+        Thread.sleep(5000)
 
         // Given the max_docs and retention settings above, the history index will rollover and the non-write index will be deleted.
         // This leaves two indices: alert index and an empty history write index

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AggregationQueryRewriterTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AggregationQueryRewriterTests.kt
@@ -128,9 +128,7 @@ class AggregationQueryRewriterTests: ESTestCase() {
     }
 
     override fun xContentRegistry(): NamedXContentRegistry {
-        super.xContentRegistry()
         val entries = ClusterModule.getNamedXWriteables()
-        CompositeAggregationBuilder.PARSER
         entries.add(
             NamedXContentRegistry.Entry(
                 Aggregation::class.java, ParseField(CompositeAggregationBuilder.NAME),

--- a/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AggregationQueryRewriterTests.kt
+++ b/alerting/src/test/kotlin/com/amazon/opendistroforelasticsearch/alerting/util/AggregationQueryRewriterTests.kt
@@ -1,0 +1,146 @@
+package com.amazon.opendistroforelasticsearch.alerting.util
+
+import com.amazon.opendistroforelasticsearch.alerting.model.InputRunResults
+import com.amazon.opendistroforelasticsearch.alerting.model.Trigger
+import com.amazon.opendistroforelasticsearch.alerting.randomAggregationTrigger
+import com.amazon.opendistroforelasticsearch.alerting.randomTraditionalTrigger
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.cluster.ClusterModule
+import org.elasticsearch.common.CheckedFunction
+import org.elasticsearch.common.ParseField
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.json.JsonXContent
+import org.elasticsearch.search.aggregations.Aggregation
+import org.elasticsearch.search.aggregations.AggregationBuilder
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder
+import org.elasticsearch.search.aggregations.bucket.composite.ParsedComposite
+import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder
+import org.elasticsearch.search.builder.SearchSourceBuilder
+import org.elasticsearch.test.ESTestCase
+import org.junit.Assert
+import java.io.IOException
+
+
+class AggregationQueryRewriterTests: ESTestCase() {
+
+    fun `test RewriteQuery empty previous result`() {
+        val triggers: MutableList<Trigger> = mutableListOf()
+        for (i in 0 until 10) {
+            triggers.add(randomAggregationTrigger())
+        }
+        val queryBuilder = SearchSourceBuilder()
+        val termAgg: AggregationBuilder = TermsAggregationBuilder("testPath").field("sports")
+        queryBuilder.aggregation(termAgg)
+        val prevResult = null
+        AggregationQueryRewriter.rewriteQuery(queryBuilder, prevResult, triggers)
+        Assert.assertEquals(queryBuilder.aggregations().pipelineAggregatorFactories.size, 10)
+    }
+
+    fun `test RewriteQuery with non-empty previous result`() {
+        val triggers: MutableList<Trigger> = mutableListOf()
+        for (i in 0 until 10) {
+            triggers.add(randomAggregationTrigger())
+        }
+        val queryBuilder = SearchSourceBuilder()
+        val termAgg: AggregationBuilder = CompositeAggregationBuilder(
+            "testPath",
+            listOf(TermsValuesSourceBuilder("k1"), TermsValuesSourceBuilder("k2"))
+        )
+        queryBuilder.aggregation(termAgg)
+        val aggTriggersAfterKey = mutableMapOf<String, Map<String, Any>?>()
+        for (trigger in triggers) {
+            aggTriggersAfterKey[trigger.id] = hashMapOf(Pair("k1", "v1"), Pair("k2", "v2"))
+        }
+        val prevResult = InputRunResults(emptyList(), null, aggTriggersAfterKey)
+        AggregationQueryRewriter.rewriteQuery(queryBuilder, prevResult, triggers)
+        Assert.assertEquals(queryBuilder.aggregations().pipelineAggregatorFactories.size, 10)
+        queryBuilder.aggregations().aggregatorFactories.forEach {
+            if (it.name.equals("testPath")) {
+                val compAgg = it as CompositeAggregationBuilder
+                val afterField = CompositeAggregationBuilder::class.java.getDeclaredField("after")
+                afterField.isAccessible = true
+                Assert.assertEquals(afterField.get(compAgg), hashMapOf(Pair("k1", "v1"), Pair("k2", "v2")))
+            }
+        }
+    }
+
+    fun `test RewriteQuery with non aggregation trigger`() {
+        val triggers: MutableList<Trigger> = mutableListOf()
+        for (i in 0 until 10) {
+            triggers.add(randomTraditionalTrigger())
+        }
+        val queryBuilder = SearchSourceBuilder()
+        val termAgg: AggregationBuilder = TermsAggregationBuilder("testPath").field("sports")
+        queryBuilder.aggregation(termAgg)
+        val prevResult = null
+        AggregationQueryRewriter.rewriteQuery(queryBuilder, prevResult, triggers)
+        Assert.assertEquals(queryBuilder.aggregations().pipelineAggregatorFactories.size, 0)
+    }
+
+    fun `test after keys from search response`() {
+        val responseContent = """
+        {
+          "took" : 97,
+          "timed_out" : false,
+          "_shards" : {
+            "total" : 3,
+            "successful" : 3,
+            "skipped" : 0,
+            "failed" : 0
+          },
+          "hits" : {
+            "total" : {
+              "value" : 20,
+              "relation" : "eq"
+            },
+            "max_score" : null,
+            "hits" : [ ]
+          },
+          "aggregations" : {
+            "composite#testPath" : {
+              "after_key" : {
+                "sport" : "Basketball"
+              },
+              "buckets" : [
+                {
+                  "key" : {
+                    "sport" : "Basketball"
+                  },
+                  "doc_count" : 5
+                }
+              ]
+            }
+          }
+        }
+        """.trimIndent()
+
+        val aggTriggers: MutableList<Trigger> = mutableListOf(randomAggregationTrigger())
+        val tradTriggers: MutableList<Trigger> = mutableListOf(randomTraditionalTrigger())
+
+        val searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, responseContent))
+        val afterKeys = AggregationQueryRewriter.getAfterKeysFromSearchResponse(searchResponse, aggTriggers)
+        Assert.assertEquals(afterKeys[aggTriggers[0].id], hashMapOf(Pair("sport", "Basketball")))
+
+        val afterKeys2 = AggregationQueryRewriter.getAfterKeysFromSearchResponse(searchResponse, tradTriggers)
+        Assert.assertEquals(afterKeys2.size, 0)
+    }
+
+    override fun xContentRegistry(): NamedXContentRegistry {
+        super.xContentRegistry()
+        val entries = ClusterModule.getNamedXWriteables()
+        CompositeAggregationBuilder.PARSER
+        entries.add(
+            NamedXContentRegistry.Entry(
+                Aggregation::class.java, ParseField(CompositeAggregationBuilder.NAME),
+                CheckedFunction<XContentParser, ParsedComposite, IOException> { parser: XContentParser? ->
+                    ParsedComposite.fromXContent(
+                        parser, "testPath"
+                    )
+                }
+            )
+        )
+        return NamedXContentRegistry(entries)
+    }
+}


### PR DESCRIPTION
Query rewriter for aggregation monitor

* adds the bucket selector conditions to the input query for agg monitor
* adds pagination after keys for all composite aggregation based triggers if
  present in previous page
* UTs for the QueryRewriter class


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
